### PR TITLE
feat: upload source maps to Datadog during MFE deploy

### DIFF
--- a/tubular/scripts/frontend_deploy.py
+++ b/tubular/scripts/frontend_deploy.py
@@ -23,6 +23,10 @@ FAIL = partial(_fail, SCRIPT_SHORTNAME)
 
 @click.command("frontend_deploy")
 @click.option(
+    '--common-config-file',
+    help='File from which common configuration variables are read.',
+)
+@click.option(
     '--env-config-file',
     help='File from which to read environment configuration variables.',
 )
@@ -40,25 +44,28 @@ FAIL = partial(_fail, SCRIPT_SHORTNAME)
     is_flag=True,
     help='Boolean to decide if Cloudflare cache needs to be purged or not.',
 )
-def frontend_deploy(env_config_file, app_name, app_dist, purge_cache):
+def frontend_deploy(common_config_file, env_config_file, app_name, app_dist, purge_cache):
     """
     Copies a frontend application to an s3 bucket.
 
     Args:
+        common_config_file (str): Path to a YAML file containing common configuration variables.
         env_config_file (str): Path to a YAML file containing environment configuration variables.
         app_name (str): Name of the frontend app.
         app_dist (str): Path to frontend application dist directory.
         purge_cache (bool): Should Cloudflare cache needs to be purged.
     """
 
-    if not env_config_file:
-        FAIL(1, 'Environment config file was not specified.')
     if not app_name:
         FAIL(1, 'Frontend application name was not specified.')
     if not app_dist:
         FAIL(1, 'Frontend application dist path was not specified.')
+    if not common_config_file:
+        FAIL(1, 'Common config file was not specified.')
+    if not env_config_file:
+        FAIL(1, 'Environment config file was not specified.')
 
-    deployer = FrontendDeployer(env_config_file, app_name)
+    deployer = FrontendDeployer(common_config_file, env_config_file, app_name)
     bucket_name = deployer.env_cfg.get('S3_BUCKET_NAME')
     if not bucket_name:
         FAIL(1, 'No S3 bucket name configured for {}.'.format(app_name))

--- a/tubular/scripts/frontend_multi_deploy.py
+++ b/tubular/scripts/frontend_multi_deploy.py
@@ -23,6 +23,10 @@ FAIL = partial(_fail, SCRIPT_SHORTNAME)
 
 @click.command("frontend_deploy")
 @click.option(
+    '--common-config-file',
+    help='File from which common configuration variables are read.',
+)
+@click.option(
     '--env-config-file',
     help='File from which to read environment configuration variables.',
 )
@@ -40,27 +44,30 @@ FAIL = partial(_fail, SCRIPT_SHORTNAME)
     is_flag=True,
     help='Boolean to decide if Cloudflare cache needs to be purged or not.',
 )
-def frontend_deploy(env_config_file, app_name, app_dist, purge_cache):
+def frontend_deploy(common_config_file, env_config_file, app_name, app_dist, purge_cache):
     """
     Copies a frontend application to an s3 bucket.
 
     Args:
+        common_config_file (str): Path to a YAML file containing common configuration variables.
         env_config_file (str): Path to a YAML file containing environment configuration variables.
         app_name (str): Name of the frontend app.
         app_dist (str): Path to frontend application dist directory.
         purge_cache (bool): Should Cloudflare cache needs to be purged.
     """
 
-    if not env_config_file:
-        FAIL(1, 'Environment config file was not specified.')
     if not app_name:
         FAIL(1, 'Frontend application name was not specified.')
     if not app_dist:
         FAIL(1, 'Frontend application dist path was not specified.')
+    if not common_config_file:
+        FAIL(1, 'Common config file was not specified.')
+    if not env_config_file:
+        FAIL(1, 'Environment config file was not specified.')
 
     # We are deploying ALL sites to a single bucket so they live at
     # /<hostname>/ within the global bucket.
-    deployer = FrontendDeployer(env_config_file, app_name)
+    deployer = FrontendDeployer(common_config_file, env_config_file, app_name)
     bucket_name = deployer.env_cfg.get('BUCKET_NAME')
     if not bucket_name:
         FAIL(1, 'No S3 bucket name configured for {}.'.format(app_name))


### PR DESCRIPTION
Related PR: https://github.com/edx/edx-internal/pull/10993

https://docs.datadoghq.com/real_user_monitoring/guide/upload-javascript-source-maps/

Without source maps uploaded to Datadog for MFEs, any reported JS errors are largely not actionable as engineers cannot discern which specific area of code caused the exception due to minified production JS code.

Example from Datadog docs:

### Without source maps

JS error without any clues to to which code area/path triggered the error:

![image](https://github.com/edx/tubular/assets/2828721/5d213a64-73b5-4f7e-a909-51a8caed68c3)

### With source maps

Human-readable unminified source code of the exact line of JS code that triggered the error, including a direct link to source code on GitHub:

![image](https://github.com/edx/tubular/assets/2828721/1993f474-8dd0-48ce-84b2-689330148260)



