### PR TITLE
chore: introduce support for NPM_DEPLOY config for MFEs wrt uploading JS source maps to Datadog

### DIFF
--- a/tubular/scripts/frontend_utils.py
+++ b/tubular/scripts/frontend_utils.py
@@ -265,7 +265,7 @@ class FrontendDeployer(FrontendUtils):
             self.LOG('Could not find version for app {} while uploading source maps.'.format(self.app_name))
             return
 
-        # Successfully determined service and version for the deployment and installed ``@datadog/datadog-ci``.
+        # Successfully determined service and version for the app deployment
         return service, version
 
     def _upload_js_sourcemaps(self, app_path):


### PR DESCRIPTION
The `datadog-ci` command, installed via the `@datadog/datadog-ci` NPM package appears to be missing in the current implementation of the `FrontendDeployer` on a recent test of the stage deployment pipeline:

```
/bin/sh: 1: ./node_modules/.bin/datadog-ci: not found
b'Deploy frontend: Uploading source maps to Datadog for app frontend-app-learner-portal-enterprise.'
b'Deploy frontend: Could not upload source maps to Datadog for app frontend-app-learner-portal-enterprise.'
```

This issue is likely due to the `@datadog/datadog-ci` NPM package only getting installed during `FrontendBuilder`, such that when `FrontendDeployer` is run, the previously installed NPM package exposing the `datadog-ci` command is no longer installed since it's a separate environment from the `FrontendBuilder`.

Given this issue, this PR proposes setting a `NPM_DEPLOY` config setting in edx-internal's common MFE configuration, defining NPM packages to be installed for the purpose of deployment. For now, this would only be `@datadog/datadog-ci`, but could be expanded for future use cases as well.

The alternative considered was having `FrontendBuilder` install the `@datadog/datadog-ci` NPM package directly (hardcoded in `edx/tubular`). However, this approach was decided against in favor of the more generalized `NPM_DEPLOY` defined via edx-internal's common MFE configuration instead, for parity with `NPM_PRIVATE` and `NPM_ALIASES`.

`NPM_PRIVATE` are private packages that the build application relies on; similarly, `NPM_ALIASES` are installed packages that are aliased via package.json definitions.

`NPM_DEPLOY` differs because the packages listed here are not relevant to the built application; only in support of the deployment.

Related PRs:
* https://github.com/edx/edx-internal/pull/11050