### PR TITLE
fix: update command args for datadog-ci

### DIFF
--- a/tubular/scripts/frontend_utils.py
+++ b/tubular/scripts/frontend_utils.py
@@ -277,7 +277,7 @@ class FrontendDeployer(FrontendUtils):
 
         command_args = ' '.join([
             f'--service="{service}"',
-            f'--release-version="{version}"'
+            f'--release-version="{version}"',
             '--minified-path-prefix="/"',  # Sourcemaps are relative to the root when deployed
         ])
         self.LOG('Uploading source maps to Datadog for app {}.'.format(self.app_name))


### PR DESCRIPTION
After resolving the `datadog-ci` command missing issue, a different issue arose where the `--minified-path-prefix` appears to be missing:

```shell
Missing minified path
b'Deploy frontend: Uploading source maps to Datadog for app frontend-app-learner-portal-enterprise.'
b'Deploy frontend: Could not upload source maps to Datadog for app frontend-app-learner-portal-enterprise.'
```

`@datadog/datadog-ci` source throwing that error message: https://github.com/DataDog/datadog-ci/blob/bff12e212215133d0eb59ae1814d052a2ee886c2/src/commands/sourcemaps/upload.ts#L87-L91

Turns out the `command_args` concatenated was missing a comma between `--release-version` and `--minified-path-prefix`.

With an added comma, it should be treated as 3 independent command arguments instead. 