### PR TITLE
fix: pass `--project-path` option when uploading JS sourcemaps to Datadog

### DIFF
--- a/tubular/scripts/frontend_utils.py
+++ b/tubular/scripts/frontend_utils.py
@@ -278,6 +278,7 @@ class FrontendDeployer(FrontendUtils):
         command_args = ' '.join([
             f'--service="{service}"',
             f'--release-version="{version}"',
+            f'--project-path="{self.app_name}/"',
             '--minified-path-prefix="/"',  # Sourcemaps are relative to the root when deployed
         ])
         self.LOG('Uploading source maps to Datadog for app {}.'.format(self.app_name))


### PR DESCRIPTION
```shell
Starting upload with concurrency 20. 
Will look for sourcemaps in target/dist
Will match JS files for errors on files starting with /
version: b533813f29e4221ab3b48c51b55c5f9710776118 service: edx-frontend-app-learner-portal-enterprise project path: 

Command summary:
⚠️ No sourcemaps detected. Did you specify the correct directory?
b'Deploy frontend: Uploading source maps to Datadog for app frontend-app-learner-portal-enterprise.'
```

When attempting an MFE deployment, `datadog-ci` is failing to detect JS source maps in the `dist` directory. This PR attempts to resolve by providing the `--project-path` command arg to `datadog-ci` per the [Datadog documentation](https://github.com/DataDog/datadog-ci/tree/master/src/commands/sourcemaps#setting-the-project-path):

<img width="996" alt="image" src="https://github.com/edx/tubular/assets/2828721/c8b22106-5e59-4d6f-93dd-4ec544005ad0">

<img width="1019" alt="image" src="https://github.com/edx/tubular/assets/2828721/b4f65f2e-059a-4cd2-a0df-46c1af0d5db8">

When looking at the sourcemaps generated by `@openedx/frontend-build`, the file paths do seem to reference a prefix of the app name. Example:

```
{
  "sources": [
    "webpack://frontend-app-learner-portal-enterprise/./src/components/integration-warning-modal/ModalBody.jsx"
  ],
}
```

This PR attempts to see if sourcemaps can be detected by providing the `f'--project-path="{self.app_name}/"', to the Datadog CLI command.