### PR TITLE
chore: remove cwd from datadog-ci sourcemaps upload

### DIFF
--- a/tubular/scripts/frontend_utils.py
+++ b/tubular/scripts/frontend_utils.py
@@ -233,7 +233,6 @@ class FrontendDeployer(FrontendUtils):
             install_list = ' '.join(npm_deploy)
             install_private_proc = subprocess.Popen(
                 [f'npm install {install_list} --no-save'],
-                cwd=self.app_name,
                 shell=True
             )
             install_private_proc_return_code = install_private_proc.wait()
@@ -300,7 +299,6 @@ class FrontendDeployer(FrontendUtils):
                 app_dist,
                 command_args,
             ]),
-            cwd=self.app_name,
             shell=True,
         )
         return_code = proc.wait()


### PR DESCRIPTION
The debug logs confirmed the sourcemaps do in fact exist within `app_dist`. Given this, I believe the culprit may be due to passing `cwd=self.app_name` when running the `datadog-ci` CLI command.

The default current working directory within `FrontendDeployer` is as follows, and contains the below directories:

```shell
b'Deploy frontend: [DEBUG] Current working directory: /godata/pipelines/stage-frontend-app-learner-portal-enterprise'
```

```shell
b"Deploy frontend: [DEBUG] current working directory contents: ['edx-internal', 'tubular', 'frontend-app-learner-portal-enterprise', 'target']"
```

The default current working directory contains the `target` directory (i.e., the resulting build output from `FrontendBuilder`). However, running the `datadog-ci` command within the `frontend-app-learner-portal-enterprise` directory (due to the `cwd=self.app_name`) means the `target` directory is not reachable since it's not a descendent of `cwd=self.app_name`.

The output of the `app_dist` is what we'd expect, containing the built JS source and sourcemap files:

```shell
b"Deploy frontend: [DEBUG] app_dist contents: ['8030.9e695bd04644a14a18c5.js.map', '27dd23381721eb3498bae7a80ad4facd.jpg', '5885.55e2fc782bce49685e85.js.LICENSE.txt', '8358.b325417e68a39e55915b.js.map', '3638.74d07288636b4363e5ba.js.map', '9629.0be115a201f88cd6b458.css', '6592.0550914088cb483fb9c8.js.map', '1981.52ef16ad0794137db7d1.js.map', 'app-84781932.a09ea94d8b4f3b86d496.js.map', '8396.b6f9bd8bfdd7e3057a5d.js.map', ...]
```