### PR TITLE
chore: remove temp debug logs

### DIFF
--- a/tubular/scripts/frontend_utils.py
+++ b/tubular/scripts/frontend_utils.py
@@ -279,7 +279,7 @@ class FrontendDeployer(FrontendUtils):
             f'--release-version="{version}"',
             f'--project-path="{self.app_name}/"',
             '--minified-path-prefix="/"',  # Sourcemaps are relative to the root when deployed
-            '--disable-git',
+            '--disable-git',  # Disable Datadog's git integration as the current working directory is not a git repo
         ])
         self.LOG('Uploading source maps to Datadog for app {}.'.format(self.app_name))
         proc = subprocess.Popen(

--- a/tubular/scripts/frontend_utils.py
+++ b/tubular/scripts/frontend_utils.py
@@ -279,6 +279,7 @@ class FrontendDeployer(FrontendUtils):
             f'--release-version="{version}"',
             f'--project-path="{self.app_name}/"',
             '--minified-path-prefix="/"',  # Sourcemaps are relative to the root when deployed
+            '--disable-git',
         ])
         self.LOG('Uploading source maps to Datadog for app {}.'.format(self.app_name))
         proc = subprocess.Popen(

--- a/tubular/scripts/frontend_utils.py
+++ b/tubular/scripts/frontend_utils.py
@@ -274,18 +274,6 @@ class FrontendDeployer(FrontendUtils):
             # Could not determine appropriate service or version for app; skipping.
             return
 
-        # [DEBUG] Temporarily log the current working directory
-        cwd = os.getcwd()
-        self.LOG(f'[DEBUG] Current working directory: {cwd}')
-
-        # [DEBUG] Temporarily log the files in `app_dist` to observe which files are returned.
-        dist_files = os.listdir(app_dist)
-        self.LOG(f'[DEBUG] app_dist contents: {dist_files}')
-
-        # [DEBUG] Temporarily log the files in current working directory to observe which files are returned.
-        cwd_files = os.listdir(cwd)
-        self.LOG(f'[DEBUG] current working directory contents: {cwd_files}')
-
         command_args = ' '.join([
             f'--service="{service}"',
             f'--release-version="{version}"',


### PR DESCRIPTION
The `datadog-ci` JS sourcemaps upload appears to have succeeded on the most recent attempt. Sample output from the logs:

```shell
Uploading sourcemap target/dist/runtime.7c33e67943737a8a499d.js.map for JS file available at runtime.7c33e67943737a8a499d.js
Uploading sourcemap target/dist/videojs.a469a7b0bdf0329477a2.js.map for JS file available at videojs.a469a7b0bdf0329477a2.js

Command summary:
✅ Uploaded 81 sourcemaps in 1.629 seconds.
```

Note, however, the following output:

```shell
⚠️ An error occured while invoking git: Error: fatal: not a git repository (or any of the parent directories): .git

Make sure the command is running within your git repository to fully leverage Datadog's git integration.
To ignore this warning use the --disable-git flag.
```

This PR intends to remove the temporarily debug logging previously introduced, deferring on the Datadog git integration, by passing `--disable-git` to ignore this warning for now.