### PR TITLE
fix: fix github_api to consider commits without checks as passing

### DIFF
--- a/tubular/github_api.py
+++ b/tubular/github_api.py
@@ -591,8 +591,11 @@ class GitHubAPI:
         )
         def _run():
             result = self._is_commit_successful(sha)
+            if result[0] == False:  # No Checks found against the Commit
+                # Returning any string other than '' will set the commit status to succeed. 
+                # Returning 'success' to avoid breaking pipeline checks in case no actions are found
+                return ("success", None)
             return (result[2], result[1])
-
         return _run()
 
     def poll_pull_request_test_status(self, pr_number):


### PR DESCRIPTION
## Description
- Potential solution to fix the issue reported in the [DOS-4930](https://2u-internal.atlassian.net/browse/DOS-4930).
- The implemented solution can also have another approach which has been mentioned on the ticket itself.

## Impact
- Merging this solution should potentially resolve the issue where github_api doesn't return correct value pair for the commits where no checks are present. It handles the scenario where a PR with multiple commits is merged into master and GitHub only runs checks against the most recent commit but leaves the rest of the commits as it is without any actions information against them. 
- Further details and POC for the solution along with testing are present on the linked ticket. 

## TODO
- If the implemented solution still doesn't work, it may be needed to set the repo merge rules to only allow `squash and merge` for the PRs to avoid such commits altogether on master/main branch. If the fix is successful, this follow-up step won't be needed.