### PR TITLE
Revert "chore: Upgrade Python requirements"

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,31 +4,33 @@
 #
 #    make upgrade
 #
-asgiref==3.8.1
+asgiref==3.7.2
     # via django
-attrs==24.2.0
+attrs==23.1.0
     # via
     #   jsonlines
     #   zeep
 backoff==2.2.1
     # via -r requirements/base.in
-boto3==1.35.54
+beautifulsoup4==4.12.2
+    # via cloudflare
+boto3==1.28.68
     # via -r requirements/base.in
-botocore==1.35.54
+botocore==1.31.68
     # via
     #   boto3
     #   s3transfer
-cachetools==5.5.0
+cachetools==5.3.1
     # via google-auth
-certifi==2024.8.30
+certifi==2023.7.22
     # via
     #   kubernetes
     #   requests
-cffi==1.17.1
+cffi==1.16.0
     # via
     #   cryptography
     #   pynacl
-charset-normalizer==3.4.0
+charset-normalizer==3.3.1
     # via requests
 click==8.1.7
     # via
@@ -37,15 +39,15 @@ click==8.1.7
     #   edx-django-utils
 click-log==0.4.0
     # via -r requirements/base.in
-cloudflare==2.20.0
+cloudflare==2.12.4
+    # via -r requirements/base.in
+cryptography==41.0.4
     # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
-cryptography==43.0.3
-    # via pyjwt
+    #   pyjwt
+    #   simple-salesforce
 deprecated==1.2.14
     # via pygithub
-django==3.2.25
+django==3.2.22
     # via
     #   -c requirements/constraints.txt
     #   django-crum
@@ -53,53 +55,49 @@ django==3.2.25
     #   edx-django-utils
 django-crum==0.7.9
     # via edx-django-utils
-django-waffle==4.1.0
+django-waffle==4.0.0
     # via edx-django-utils
-dnspython==2.6.1
-    # via pymongo
-durationpy==0.9
-    # via kubernetes
-easydict==1.13
+easydict==1.10
     # via yagocd
-edx-django-utils==7.0.0
+edx-django-utils==5.7.0
     # via edx-rest-api-client
-edx-opaque-keys==2.11.0
+edx-opaque-keys==2.5.1
     # via -r requirements/base.in
-edx-rest-api-client==6.0.0
+edx-rest-api-client==5.6.1
     # via -r requirements/base.in
-freezegun==1.5.1
+freezegun==1.2.2
     # via -r requirements/base.in
 gitdb==4.0.11
     # via gitpython
-gitpython==3.1.43
+gitpython==3.1.40
     # via -r requirements/base.in
-google-api-core==2.22.0
+google-api-core==2.12.0
     # via google-api-python-client
 google-api-python-client==1.12.11
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-google-auth==2.35.0
+google-auth==2.23.3
     # via
     #   google-api-core
     #   google-api-python-client
     #   google-auth-httplib2
     #   kubernetes
-google-auth-httplib2==0.2.0
+google-auth-httplib2==0.1.1
     # via google-api-python-client
-googleapis-common-protos==1.65.0
+googleapis-common-protos==1.61.0
     # via google-api-core
 httplib2==0.22.0
     # via
     #   google-api-python-client
     #   google-auth-httplib2
-idna==3.10
+idna==3.4
     # via requests
-isodate==0.7.2
+isodate==0.6.1
     # via zeep
 jenkinsapi==0.3.13
     # via -r requirements/base.in
-jinja2==3.1.4
+jinja2==3.1.2
     # via -r requirements/base.in
 jmespath==1.0.1
     # via
@@ -107,49 +105,48 @@ jmespath==1.0.1
     #   botocore
 jsonlines==4.0.0
     # via cloudflare
-kubernetes==31.0.0
+kubernetes==28.1.0
     # via -r requirements/base.in
-lxml==5.3.0
+lxml==4.9.3
     # via zeep
-markupsafe==2.1.5
+markupsafe==2.1.3
     # via jinja2
-more-itertools==10.5.0
+more-itertools==10.1.0
     # via simple-salesforce
-newrelic==10.2.0
+newrelic==9.1.1
     # via edx-django-utils
 oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
-pbr==6.1.0
+pbr==5.11.1
     # via stevedore
-platformdirs==4.3.6
+pendulum==2.1.2
+    # via simple-salesforce
+platformdirs==3.11.0
     # via zeep
-proto-plus==1.25.0
-    # via google-api-core
-protobuf==5.28.3
+protobuf==4.24.4
     # via
     #   google-api-core
     #   googleapis-common-protos
-    #   proto-plus
-psutil==6.1.0
+psutil==5.9.6
     # via edx-django-utils
-pyasn1==0.6.1
+pyasn1==0.5.0
     # via
     #   pyasn1-modules
     #   rsa
-pyasn1-modules==0.4.1
+pyasn1-modules==0.3.0
     # via google-auth
-pycparser==2.22
+pycparser==2.21
     # via cffi
-pygithub==2.4.0
+pygithub==2.1.1
     # via -r requirements/base.in
-pyjwt[crypto]==2.9.0
+pyjwt[crypto]==2.8.0
     # via
     #   edx-rest-api-client
     #   pygithub
     #   simple-salesforce
-pymongo==4.10.1
+pymongo==3.13.0
     # via
     #   -r requirements/base.in
     #   edx-opaque-keys
@@ -157,25 +154,29 @@ pynacl==1.5.0
     # via
     #   edx-django-utils
     #   pygithub
-pyparsing==3.1.4
+pyparsing==3.1.1
     # via httplib2
-python-dateutil==2.9.0.post0
+python-dateutil==2.8.2
     # via
     #   botocore
     #   freezegun
     #   kubernetes
-pytz==2024.2
+    #   pendulum
+    #   pygithub
+pytz==2023.3.post1
     # via
     #   -r requirements/base.in
     #   django
     #   jenkinsapi
     #   zeep
-pyyaml==6.0.2
+pytzdata==2020.1
+    # via pendulum
+pyyaml==6.0.1
     # via
     #   -r requirements/base.in
     #   cloudflare
     #   kubernetes
-requests==2.32.3
+requests==2.31.0
     # via
     #   -r requirements/base.in
     #   cloudflare
@@ -189,65 +190,71 @@ requests==2.32.3
     #   requests-toolbelt
     #   sailthru-client
     #   simple-salesforce
+    #   slumber
     #   yagocd
     #   zeep
-requests-file==2.1.0
+requests-file==1.5.1
     # via zeep
-requests-oauthlib==2.0.0
+requests-oauthlib==1.3.1
     # via kubernetes
 requests-toolbelt==1.0.0
     # via zeep
 rsa==4.9
     # via google-auth
-s3transfer==0.10.3
+s3transfer==0.7.0
     # via boto3
 sailthru-client==2.3.5
     # via -r requirements/base.in
-simple-salesforce==1.12.6
+simple-salesforce==1.12.5
     # via -r requirements/base.in
-simplejson==3.19.3
+simplejson==3.19.2
     # via sailthru-client
 six==1.16.0
     # via
     #   -r requirements/base.in
     #   google-api-python-client
+    #   isodate
     #   jenkinsapi
     #   kubernetes
     #   python-dateutil
+    #   requests-file
     #   yagocd
+slumber==0.7.1
+    # via edx-rest-api-client
 smmap==5.0.1
     # via gitdb
-sqlparse==0.5.1
+soupsieve==2.5
+    # via beautifulsoup4
+sqlparse==0.4.4
     # via django
-stevedore==5.3.0
+stevedore==5.1.0
     # via
     #   edx-django-utils
     #   edx-opaque-keys
-typing-extensions==4.12.2
+typing-extensions==4.8.0
     # via
     #   asgiref
     #   edx-opaque-keys
     #   pygithub
-    #   simple-salesforce
 unicodecsv==0.14.1
     # via -r requirements/base.in
 uritemplate==3.0.1
     # via google-api-python-client
-urllib3==1.26.20
+urllib3==1.26.18
     # via
     #   botocore
     #   kubernetes
     #   pygithub
     #   requests
-validators==0.34.0
+validators==0.22.0
     # via -r requirements/base.in
-websocket-client==1.8.0
+websocket-client==1.6.4
     # via kubernetes
-wrapt==1.16.0
+wrapt==1.15.0
     # via
     #   -r requirements/base.in
     #   deprecated
 yagocd==1.0.1
     # via -r requirements/base.in
-zeep==4.3.1
+zeep==4.2.1
     # via simple-salesforce

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -16,5 +16,3 @@ responses<0.21.0
 django<4.0
 setuptools<60
 google-api-python-client<2
-moto<5.0
-cloudflare<3.0

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,27 +4,26 @@
 #
 #    make upgrade
 #
-build==1.2.2.post1
+build==1.0.3
     # via pip-tools
 click==8.1.7
     # via pip-tools
-importlib-metadata==8.5.0
+importlib-metadata==6.8.0
     # via build
-packaging==24.1
+packaging==23.2
     # via build
-pip-tools==7.4.1
+pip-tools==7.3.0
     # via -r requirements/pip-tools.in
-pyproject-hooks==1.2.0
+pyproject-hooks==1.0.0
+    # via build
+tomli==2.0.1
     # via
     #   build
     #   pip-tools
-tomli==2.0.2
-    # via
-    #   build
-    #   pip-tools
-wheel==0.44.0
+    #   pyproject-hooks
+wheel==0.41.2
     # via pip-tools
-zipp==3.20.2
+zipp==3.17.0
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-wheel==0.44.0
+wheel==0.41.2
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==24.3.1
+pip==23.3.1
     # via -r requirements/pip.in
 setuptools==59.8.0
     # via

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -4,23 +4,23 @@
 #
 #    make upgrade
 #
-astroid==3.2.4
+astroid==3.0.1
     # via
     #   -r requirements/testing.in
     #   pylint
     #   pylint-celery
-boto3==1.35.54
+boto3==1.28.68
     # via moto
-botocore==1.35.54
+botocore==1.31.68
     # via
     #   boto3
     #   moto
     #   s3transfer
-certifi==2024.8.30
+certifi==2023.7.22
     # via requests
-cffi==1.17.1
+cffi==1.16.0
     # via cryptography
-charset-normalizer==3.4.0
+charset-normalizer==3.3.1
     # via requests
 click==8.1.7
     # via
@@ -29,31 +29,33 @@ click==8.1.7
     #   edx-lint
 click-log==0.4.0
     # via edx-lint
-code-annotations==1.8.0
+code-annotations==1.5.0
     # via edx-lint
-coverage[toml]==7.6.1
-    # via pytest-cov
-cryptography==43.0.3
+coverage[toml]==7.3.2
+    # via
+    #   coverage
+    #   pytest-cov
+cryptography==41.0.4
     # via moto
-ddt==1.7.2
+ddt==1.6.0
     # via -r requirements/testing.in
-dill==0.3.9
+dill==0.3.7
     # via pylint
-edx-lint==5.4.1
+edx-lint==5.3.4
     # via -r requirements/testing.in
-exceptiongroup==1.2.2
+exceptiongroup==1.1.3
     # via pytest
-execnet==2.1.1
+execnet==2.0.2
     # via pytest-xdist
 httpretty==1.1.4
     # via -r requirements/testing.in
-idna==3.10
+idna==3.4
     # via requests
 iniconfig==2.0.0
     # via pytest
-isort==5.13.2
+isort==5.12.0
     # via pylint
-jinja2==3.1.4
+jinja2==3.1.2
     # via
     #   code-annotations
     #   moto
@@ -61,7 +63,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-markupsafe==2.1.5
+markupsafe==2.1.3
     # via
     #   jinja2
     #   werkzeug
@@ -69,27 +71,25 @@ mccabe==0.7.0
     # via pylint
 mock==5.1.0
     # via -r requirements/testing.in
-moto==4.2.14
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/testing.in
-packaging==24.1
+moto==4.2.6
+    # via -r requirements/testing.in
+packaging==23.2
     # via pytest
-pbr==6.1.0
+pbr==5.11.1
     # via stevedore
-platformdirs==4.3.6
+platformdirs==3.11.0
     # via pylint
-pluggy==1.5.0
+pluggy==1.3.0
     # via pytest
 py==1.11.0
     # via pytest-pycodestyle
-pycodestyle==2.12.1
+pycodestyle==2.11.1
     # via
     #   -r requirements/testing.in
     #   pytest-pycodestyle
-pycparser==2.22
+pycparser==2.21
     # via cffi
-pylint==3.2.7
+pylint==3.0.2
     # via
     #   -r requirements/testing.in
     #   edx-lint
@@ -99,77 +99,78 @@ pylint==3.2.7
     #   pytest-pylint
 pylint-celery==0.3
     # via edx-lint
-pylint-django==2.5.5
+pylint-django==2.5.4
     # via edx-lint
 pylint-plugin-utils==0.8.2
     # via
     #   pylint-celery
     #   pylint-django
-pytest==8.3.3
+pytest==7.4.2
     # via
     #   -r requirements/testing.in
     #   pytest-cov
     #   pytest-pycodestyle
     #   pytest-pylint
     #   pytest-xdist
-pytest-cov==5.0.0
+pytest-cov==4.1.0
     # via -r requirements/testing.in
 pytest-pycodestyle==2.3.1
     # via -r requirements/testing.in
 pytest-pylint==0.21.0
     # via -r requirements/testing.in
-pytest-xdist==3.6.1
+pytest-xdist==3.3.1
     # via -r requirements/testing.in
-python-dateutil==2.9.0.post0
+python-dateutil==2.8.2
     # via
     #   botocore
     #   moto
-python-slugify==8.0.4
+python-slugify==8.0.1
     # via code-annotations
-pyyaml==6.0.2
+pyyaml==6.0.1
     # via code-annotations
-requests==2.32.3
+requests==2.31.0
     # via
     #   moto
     #   requests-mock
     #   responses
-requests-mock==1.12.1
+requests-mock==1.11.0
     # via -r requirements/testing.in
 responses==0.20.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/testing.in
     #   moto
-s3transfer==0.10.3
+s3transfer==0.7.0
     # via boto3
 six==1.16.0
     # via
     #   edx-lint
     #   python-dateutil
-stevedore==5.3.0
+    #   requests-mock
+stevedore==5.1.0
     # via code-annotations
 text-unidecode==1.3
     # via python-slugify
-tomli==2.0.2
+tomli==2.0.1
     # via
     #   coverage
     #   pylint
     #   pytest
     #   pytest-pylint
-tomlkit==0.13.2
+tomlkit==0.12.1
     # via pylint
-typing-extensions==4.12.2
+typing-extensions==4.8.0
     # via
     #   astroid
     #   pylint
-urllib3==1.26.20
+urllib3==1.26.18
     # via
     #   botocore
     #   requests
     #   responses
-werkzeug==3.0.6
+werkzeug==3.0.0
     # via moto
-wrapt==1.16.0
+wrapt==1.15.0
     # via -r requirements/testing.in
-xmltodict==0.14.2
+xmltodict==0.13.0
     # via moto


### PR DESCRIPTION
Reverts edx/tubular#15

A deployment to prod with this PR yesterday broke Studio's ability to load unit pages. A rollback of the deployment restored Studio functionality, so one of the PRs in the deployment was at fault.

This was one of several PRs in the deployment, and this is an experimental revert, to attempt to restore Studio functionality.

