### PR TITLE
fix: Add timeout to retrieve_latest_base_ami.py

### DIFF
--- a/tubular/scripts/retrieve_latest_base_ami.py
+++ b/tubular/scripts/retrieve_latest_base_ami.py
@@ -127,7 +127,8 @@ def _backoff_logger(details):
     max_tries=5, jitter=backoff.random_jitter, on_backoff=_backoff_logger,
 )
 def get_with_retry(url):
-    data = requests.get(url)
+    # Set timeout to 1 minute to ensure open connections get killed.
+    data = requests.get(url, timeout=60)
     return data
 
 


### PR DESCRIPTION
We were seeing some connections hang. This ensures that we can kill misbehaving attempts and then retry them.

https://github.com/edx/edx-arch-experiments/issues/886