### PR TITLE
chore: adding feature flags json list in env variables

### DIFF
--- a/tubular/scripts/frontend_utils.py
+++ b/tubular/scripts/frontend_utils.py
@@ -67,6 +67,7 @@ class FrontendUtils:
         """ Combines the common and environment configs APP_CONFIG data """
         app_config = self.common_cfg.get('APP_CONFIG', {})
         app_config.update(self.env_cfg.get('APP_CONFIG', {}))
+        app_config.update(self.env_cfg.get('FEATURE_FLAGS', {}))
         app_config['APP_VERSION'] = self.get_version_commit_sha()
         app_config['FEATURE_FLAGS'] = self.get_feature_flags()
         if not app_config:

--- a/tubular/scripts/frontend_utils.py
+++ b/tubular/scripts/frontend_utils.py
@@ -68,9 +68,16 @@ class FrontendUtils:
         app_config = self.common_cfg.get('APP_CONFIG', {})
         app_config.update(self.env_cfg.get('APP_CONFIG', {}))
         app_config['APP_VERSION'] = self.get_version_commit_sha()
+        app_config['FEATURE_FLAGS'] = self.get_feature_flags()
         if not app_config:
             self.LOG('Config variables do not exist for app {}.'.format(self.app_name))
         return app_config
+
+    def get_feature_flags(self):
+        """ Accesses the feature flags from config and JSON encodes it to be placed in env variables """
+        feature_flags = self.env_cfg.get('FEATURE_FLAGS', {})
+        feature_flag_json = json.dumps(feature_flags)
+        return feature_flag_json
 
     def get_version_commit_sha(self):
         """ Returns the commit SHA of the current HEAD """


### PR DESCRIPTION
This PR fetches the Feature flags list from stage config, parse to JSON string and places it to env variables for MFE so it can be accessed at the time of logging initialization. 
Issue Link: https://github.com/edx/edx-arch-experiments/issues/635