### PR TITLE
Bszabo/testing args from gocd

### DIFF
--- a/tubular/scripts/dd_synthetic_tests.py
+++ b/tubular/scripts/dd_synthetic_tests.py
@@ -129,6 +129,7 @@ class DatadogClient:
         }
         test_public_ids = self.tests_by_public_id.keys()
         json_request_body = {"tests": [{"public_id": public_id} for public_id in test_public_ids]}
+        logging.info(f'Trigger request body: {json_request_body}')
         response = requests.post(url, headers=headers, json=json_request_body)
         if response.status_code != 200:
             raise Exception(f"Datadog API error. Status = {response.status_code}")


### PR DESCRIPTION
This is an incremental merge along the path to enabling Datadog synthetic tests to automatically run immediately after deployments of the course authoring MFE.

It adds a diagnostic log message to help debug problems on the stage environment with the merge of PR https://github.com/edx/tubular/pull/22

The failing test is from an unrelated prior commit to the tubular repo