### PR TITLE
Fix datadog secrets for testing pipeline

### DIFF
--- a/tubular/scripts/dd_synthetic_tests.py
+++ b/tubular/scripts/dd_synthetic_tests.py
@@ -129,7 +129,6 @@ class DatadogClient:
         }
         test_public_ids = self.tests_by_public_id.keys()
         json_request_body = {"tests": [{"public_id": public_id} for public_id in test_public_ids]}
-        logging.info(f'Trigger request body: {json_request_body}')
         response = requests.post(url, headers=headers, json=json_request_body)
         if response.status_code != 200:
             raise Exception(f"Datadog API error. Status = {response.status_code}")
@@ -247,8 +246,8 @@ def run_synthetic_tests(enable_automated_rollbacks, timeout, tests):
         sys.exit(1)
 
     try:
-        api_key = os.getenv("DATADOG_API_KEY")
-        app_key = os.getenv("DATADOG_APP_KEY")
+        api_key = os.getenv("DATADOG_API_KEY_SYNTHETIC_TEST")
+        app_key = os.getenv("DATADOG_APP_KEY_SYNTHETIC_TEST")
         dd_client = DatadogClient(api_key, app_key)
         dd_client.timeout_secs = timeout
 

--- a/tubular/scripts/dd_synthetic_tests.py
+++ b/tubular/scripts/dd_synthetic_tests.py
@@ -129,6 +129,7 @@ class DatadogClient:
         }
         test_public_ids = self.tests_by_public_id.keys()
         json_request_body = {"tests": [{"public_id": public_id} for public_id in test_public_ids]}
+        logging.info(f'Trigger request body: {json_request_body}')
         response = requests.post(url, headers=headers, json=json_request_body)
         if response.status_code != 200:
             raise Exception(f"Datadog API error. Status = {response.status_code}")


### PR DESCRIPTION
This is an incremental merge along the path to enabling Datadog synthetic tests to automatically run immediately after deployments of the course authoring MFE. It builds on the most recent PR, https://github.com/edx/tubular/pull/24

Equivalent code was tested on the test-GoCD servers using edx/tubular and edx-gocd-synthetic-testing repos, under bszabo/testing-args-from-gocd branches. 

This PR fixes an error introduced going from the test-gocd version of the code, which did not rely on edx-internal, and the gocd version of the code, which does.

This code will be tested on the stage environment post-merge without possible harm to prod.

Testing entails:

Verifying that a new release_tests_1_pipeline pipeline has been added to the st_1_group pipeline group
Verifying that four tests run and pass when the stage environment pipeline group is run
Verifying that disabling the pipeline feature switch causes the test pipeline to return much faster, without waiting for all four tests to complete, and also that a line is logged flagging the behavior