### PR TITLE
Datadog synthetic tests (authoring pipeline) on prod

### DIFF
--- a/tubular/scripts/dd_synthetic_tests.py
+++ b/tubular/scripts/dd_synthetic_tests.py
@@ -146,7 +146,8 @@ class DatadogClient:
     def _map_environment_resources(self, env):
         if not env or env == 'prod' or env == 'stage':
             logging.info("***** Relying on identity transformation for environment resources ***** ")
-            return [{'pattern': '(.*)', 'substitution': '$1'}]  # No change
+            return [{'pattern': '(?P<identity>.*)',
+                     'substitution': '{{identity}}'}]  # No change
         elif env == 'stage':
             return r'"(.+)\.edx.org|$1.stage.edx.org"'
         else:

--- a/tubular/scripts/dd_synthetic_tests.py
+++ b/tubular/scripts/dd_synthetic_tests.py
@@ -12,9 +12,11 @@ class SyntheticTest:
     '''
     Attributes for a Datadog synthetic test and its test run
     '''
-    def __init__(self, name, public_id):
+    def __init__(self, name, public_id, env, start_url):
         self.name = name            # The test's Datadog name
         self.public_id = public_id  # The test's Datadog Test ID
+        self.env = env              # The test environment ("stage" or "prod")
+        self.start_url = start_url  # The browser test's landing page
         self.test_run_id = None     # The run ID given by Datadog to this test's invocation
         self.success = None
 

--- a/tubular/scripts/dd_synthetic_tests.py
+++ b/tubular/scripts/dd_synthetic_tests.py
@@ -146,9 +146,9 @@ class DatadogClient:
     def _map_environment_resources(self, env):
         if not env or env == 'prod' or env == 'stage':
             logging.info("***** Relying on identity transformation for environment resources ***** ")
-            return r"(\.*)|\1"  # No change
+            return "(.*)|$1"  # No change
         elif env == 'stage':
-            return r'"(\.+)\.edx.org|\1.stage.edx.org"'
+            return r'"(.+)\.edx.org|$1.stage.edx.org"'
         else:
             raise Exception(f'Unknown {env} environment')
 

--- a/tubular/scripts/dd_synthetic_tests.py
+++ b/tubular/scripts/dd_synthetic_tests.py
@@ -146,7 +146,7 @@ class DatadogClient:
     def _map_environment_resources(self, env):
         if not env or env == 'prod' or env == 'stage':
             logging.info("***** Relying on identity transformation for environment resources ***** ")
-            return "(.*)|$1"  # No change
+            return "[{'pattern': '(.*)', 'substitution': '$1'}]"  # No change
         elif env == 'stage':
             return r'"(.+)\.edx.org|$1.stage.edx.org"'
         else:

--- a/tubular/scripts/dd_synthetic_tests.py
+++ b/tubular/scripts/dd_synthetic_tests.py
@@ -134,7 +134,8 @@ class DatadogClient:
         x = "(\w+)\.edx.org|1.stage.edx.org"
         json_request_body = {"tests": [{"public_id": test.public_id,
                                         "startUrl" : test.start_url,
-                                        "resourceUrlSubstitutionRegexes": self._map_environment_resources(test.env)}
+ #                                       "resourceUrlSubstitutionRegexes": self._map_environment_resources(test.env)
+                                       }
                                        for test in self.tests_by_public_id.values()]}
         logging.info(f'Trigger request body: {json_request_body}')
         response = requests.post(url, headers=headers, json=json_request_body)

--- a/tubular/scripts/dd_synthetic_tests.py
+++ b/tubular/scripts/dd_synthetic_tests.py
@@ -134,7 +134,7 @@ class DatadogClient:
         x = "(\w+)\.edx.org|1.stage.edx.org"
         json_request_body = {"tests": [{"public_id": test.public_id,
                                         "startUrl" : test.start_url,
-                                        "resourceUrlSubstitutionRegexes": self._map_environment_resources(test.env)
+                                        "resourceUrlSubstitutionRegexes": [self._map_environment_resources(test.env)]
                                        }
                                        for test in self.tests_by_public_id.values()]}
         logging.info(f'Trigger request body: {json_request_body}')
@@ -146,8 +146,7 @@ class DatadogClient:
     def _map_environment_resources(self, env):
         if not env or env == 'prod' or env == 'stage':
             logging.info("***** Relying on identity transformation for environment resources ***** ")
-            return [{'pattern': '(?P<identity>.*)',
-                     'substitution': '{{identity}}'}]  # No change
+            return '(?P<identity>.*)|{{identity}}'   # No change
         elif env == 'stage':
             return r'"(.+)\.edx.org|$1.stage.edx.org"'
         else:

--- a/tubular/scripts/dd_synthetic_tests.py
+++ b/tubular/scripts/dd_synthetic_tests.py
@@ -134,7 +134,7 @@ class DatadogClient:
         x = "(\w+)\.edx.org|1.stage.edx.org"
         json_request_body = {"tests": [{"public_id": test.public_id,
                                         "startUrl" : test.start_url,
- #                                       "resourceUrlSubstitutionRegexes": self._map_environment_resources(test.env)
+                                        "resourceUrlSubstitutionRegexes": self._map_environment_resources(test.env)
                                        }
                                        for test in self.tests_by_public_id.values()]}
         logging.info(f'Trigger request body: {json_request_body}')
@@ -144,7 +144,8 @@ class DatadogClient:
         return response
 
     def _map_environment_resources(self, env):
-        if not env or env == 'prod':
+        if not env or env == 'prod' or env == 'stage':
+            logging.info("***** Relying on identity transformation for environment resources ***** ")
             return r"(\.*)|\1"  # No change
         elif env == 'stage':
             return r'"(\.+)\.edx.org|\1.stage.edx.org"'

--- a/tubular/scripts/dd_synthetic_tests.py
+++ b/tubular/scripts/dd_synthetic_tests.py
@@ -133,7 +133,7 @@ class DatadogClient:
         }
         x = "(\w+)\.edx.org|1.stage.edx.org"
         json_request_body = {"tests": [{"public_id": test.public_id,
-                                        "startUrl" : test.url,
+                                        "startUrl" : test.start_url,
                                         "resourceUrlSubstitutionRegexes": self._map_environment_resources(test.env)}
                                        for test in self.tests_by_public_id.values()]}
         logging.info(f'Trigger request body: {json_request_body}')

--- a/tubular/scripts/dd_synthetic_tests.py
+++ b/tubular/scripts/dd_synthetic_tests.py
@@ -30,8 +30,8 @@ class DatadogClient:
                 Deployment testing enable test governing CI/CD synthetic testing
                 ''',
                 "sad-hqu-h33",
-                "",     # No environment applies; test is always just a summary pass or fail
-                ""      # Ditto for resource substitution
+                "stage",     # Value will be ignored by test, but Datadog doesn't want it empty
+                "dummy_url"  # Ditto
             )
 
     def __init__(self, api_key, app_key):

--- a/tubular/scripts/dd_synthetic_tests.py
+++ b/tubular/scripts/dd_synthetic_tests.py
@@ -244,7 +244,7 @@ logging.basicConfig(stream=sys.stdout, level=logging.INFO)
     help='Maximum time measured in seconds for the test batch to have run to completion'
 )
 @click.option(
-    '--environment',
+    '--environment_name',
     required=True,
     type=click.STRING,
     help='Environment to run test in ("stage" or "prod")'
@@ -255,7 +255,7 @@ logging.basicConfig(stream=sys.stdout, level=logging.INFO)
     type=click.STRING,
     help='List of tests to be run as json with description and test_id for each test'
 )
-def run_synthetic_tests(enable_automated_rollbacks, timeout, environment, tests):
+def run_synthetic_tests(enable_automated_rollbacks, timeout, environment_name, tests):
     '''
     :param enable_automated_rollbacks: Failing tests trigger a rollback in the build pipeline when true
     :param timeout: Maximum number of seconds between test kick-off and completion of the slowest test
@@ -275,8 +275,8 @@ def run_synthetic_tests(enable_automated_rollbacks, timeout, environment, tests)
 
         tests_as_dicts = json.loads(tests)
         tests_to_report_on = [SyntheticTest(d["name"],
-                                            ["public_id"],
-                                            environment,
+                                            d["public_id"],
+                                            environment_name,
                                             d["startUrl"])
                               for d in tests_as_dicts]
         dd_client.trigger_synthetic_tests(tests_to_report_on)

--- a/tubular/scripts/dd_synthetic_tests.py
+++ b/tubular/scripts/dd_synthetic_tests.py
@@ -146,7 +146,7 @@ class DatadogClient:
     def _map_environment_resources(self, env):
         if not env or env == 'prod' or env == 'stage':
             logging.info("***** Relying on identity transformation for environment resources ***** ")
-            return "[{'pattern': '(.*)', 'substitution': '$1'}]"  # No change
+            return [{'pattern': '(.*)', 'substitution': '$1'}]  # No change
         elif env == 'stage':
             return r'"(.+)\.edx.org|$1.stage.edx.org"'
         else:

--- a/tubular/scripts/dd_synthetic_tests.py
+++ b/tubular/scripts/dd_synthetic_tests.py
@@ -127,13 +127,24 @@ class DatadogClient:
             "DD-API-KEY": self.api_key,
             "DD-APPLICATION-KEY": self.app_key
         }
-        test_public_ids = self.tests_by_public_id.keys()
-        json_request_body = {"tests": [{"public_id": public_id} for public_id in test_public_ids]}
+        x = "(\w+)\.edx.org|1.stage.edx.org"
+        json_request_body = {"tests": [{"public_id": test.public_id,
+                                        "startUrl" : test.url,
+                                        "resourceUrlSubstitutionRegexes": self._map_environment_resources(test.env)}
+                                       for test in self.tests_by_public_id.values()]}
         logging.info(f'Trigger request body: {json_request_body}')
         response = requests.post(url, headers=headers, json=json_request_body)
         if response.status_code != 200:
             raise Exception(f"Datadog API error. Status = {response.status_code}")
         return response
+
+    def _map_environment_resources(self, env):
+        if not env or env == 'prod':
+            return r"(\.*)|\1"  # No change
+        elif env == 'stage':
+            return r'"(\.+)\.edx.org|\1.stage.edx.org"'
+        else:
+            raise Exception(f'Unknown {env} environment')
 
     def _record_batch_id(self, response_body):
         '''
@@ -253,7 +264,7 @@ def run_synthetic_tests(enable_automated_rollbacks, timeout, tests):
         dd_client.timeout_secs = timeout
 
         tests_as_dicts = json.loads(tests)
-        tests_to_report_on = [SyntheticTest(d["name"], d["public_id"]) for d in tests_as_dicts]
+        tests_to_report_on = [SyntheticTest(d["name"], d["public_id"], d["env"], d["startUrl"]) for d in tests_as_dicts]
         dd_client.trigger_synthetic_tests(tests_to_report_on)
         dd_client.gate_on_deployment_testing_enable_switch() # Exits summarily if test results are to be ignored
         for test in tests_to_report_on:

--- a/tubular/scripts/dd_synthetic_tests.py
+++ b/tubular/scripts/dd_synthetic_tests.py
@@ -12,11 +12,9 @@ class SyntheticTest:
     '''
     Attributes for a Datadog synthetic test and its test run
     '''
-    def __init__(self, name, public_id, env, start_url):
+    def __init__(self, name, public_id):
         self.name = name            # The test's Datadog name
         self.public_id = public_id  # The test's Datadog Test ID
-        self.env = env              # The test environment ("stage" or "prod")
-        self.start_url = start_url  # The browser test's landing page
         self.test_run_id = None     # The run ID given by Datadog to this test's invocation
         self.success = None
 
@@ -30,8 +28,6 @@ class DatadogClient:
                 Deployment testing enable test governing CI/CD synthetic testing
                 ''',
                 "sad-hqu-h33",
-                "stage",     # Value will be ignored by test, but Datadog doesn't want it empty
-                "dummy_url"  # Ditto
             )
 
     def __init__(self, api_key, app_key, environment_name):
@@ -267,8 +263,7 @@ def run_synthetic_tests(enable_automated_rollbacks, timeout, environment_name, t
 
         tests_as_dicts = json.loads(tests)
         tests_to_report_on = [SyntheticTest(d["name"],
-                                            d["public_id"],
-                                            d["startUrl"])
+                                            d["public_id"])
                               for d in tests_as_dicts]
         dd_client.trigger_synthetic_tests(tests_to_report_on)
         dd_client.gate_on_deployment_testing_enable_switch() # Exits summarily if test results are to be ignored


### PR DESCRIPTION
GoCD pipeline changes tested on stage propagating to prod for execution of Datadog synthetic tests, post-deployment.

Configuration logic tightened so that the batch of tests launched with Datadog all run on either stage or prod.

See companion edx-internal PR [here](https://github.com/edx/edx-internal/pull/12448)