### PR TITLE
feat: Add runbook option to gocd alert script

### DIFF
--- a/tubular/scripts/gocd_open_alert.py
+++ b/tubular/scripts/gocd_open_alert.py
@@ -28,7 +28,12 @@ log = logging.getLogger(__name__)
     required=True,
     help="Name of JSM team to page",
 )
-def gocd_open_alert(auth_token, responder):
+@click.option(
+    '--runbook',
+    required=False,
+    help="URL of runbook to offer in alert",
+)
+def gocd_open_alert(auth_token, responder, runbook):
     """
     Create an OpsGenie alert.
     """
@@ -50,8 +55,13 @@ def gocd_open_alert(auth_token, responder):
 
     # The alias should match the format used in tubular.scripts.gocd_close_alert.
     alias = f'gocd-pipeline-{pipeline}-{stage}-{job}'
-    message = f"[GoCD] Build Failed on {pipeline}"
-    description = f"Pipeline {pipeline} failed. Please see the build logs: {job_url} (triggered by {trigger_user})"
+    message = f"[GoCD] Pipeline failed: {pipeline}"
+    description = (
+        f"Pipeline {pipeline} failed.\n\n"
+        f"- Runbook: {runbook or '<not provided>'}\n"
+        f"- Build logs: {job_url}\n"
+        f"- Triggered by: {trigger_user}\n"
+    )
 
     log.info("Creating alert on Opsgenie")
     opsgenie = opsgenie_api.OpsGenieAPI(auth_token)

--- a/tubular/tests/test_gocd_open_alert.py
+++ b/tubular/tests/test_gocd_open_alert.py
@@ -6,32 +6,64 @@ from click.testing import CliRunner
 
 import tubular.scripts.gocd_open_alert as open_alert
 
+SAMPLE_ENV = {
+    'GO_PIPELINE_NAME': 'edxapp',
+    'GO_PIPELINE_COUNTER': '123',
+    'GO_STAGE_NAME': 'build',
+    'GO_STAGE_COUNTER': '456',
+    'GO_JOB_NAME': 'prod',
+    'GO_TRIGGER_USER': 'Alice',
+}
 
 class TestGocdOpenAlert(TestCase):
-    @patch.dict('os.environ', {
-        'GO_PIPELINE_NAME': 'edxapp',
-        'GO_PIPELINE_COUNTER': '123',
-        'GO_STAGE_NAME': 'build',
-        'GO_STAGE_COUNTER': '456',
-        'GO_JOB_NAME': 'prod',
-        'GO_TRIGGER_USER': 'Alice',
-    })
+    @patch.dict('os.environ', SAMPLE_ENV)
     @patch('tubular.scripts.gocd_open_alert.opsgenie_api.OpsGenieAPI.alert_opsgenie')
     def test_create_alert(self, mock_opsgenie_open):
-        """Test basic alert creation."""
+        """Test basic alert creation, all options."""
         script_run = CliRunner().invoke(
             open_alert.gocd_open_alert,
             catch_exceptions=False,
-            args=['--auth-token', 'XYZ', '--responder', 'Some Team'],
+            args=[
+                '--auth-token', 'XYZ',
+                '--responder', 'Some Team',
+                '--runbook', 'https://example.com/wiki/runbook',
+            ],
         )
 
         assert script_run.exit_code == 0
         mock_opsgenie_open.assert_called_once_with(
-            "[GoCD] Build Failed on edxapp",
+            "[GoCD] Pipeline failed: edxapp",
             (
-                "Pipeline edxapp failed. Please see the build logs: "
-                "https://gocd.tools.edx.org/go/tab/build/detail/edxapp/123/build/456/prod "
-                "(triggered by Alice)"
+                "Pipeline edxapp failed.\n\n"
+                "- Runbook: https://example.com/wiki/runbook\n"
+                "- Build logs: https://gocd.tools.edx.org/go/tab/build/detail/edxapp/123/build/456/prod\n"
+                "- Triggered by: Alice\n"
+            ),
+            'Some Team',
+            alias='gocd-pipeline-edxapp-build-prod',
+        )
+
+    @patch.dict('os.environ', SAMPLE_ENV)
+    @patch('tubular.scripts.gocd_open_alert.opsgenie_api.OpsGenieAPI.alert_opsgenie')
+    def test_no_runbook(self, mock_opsgenie_open):
+        """Test missing runbook URL"""
+        script_run = CliRunner().invoke(
+            open_alert.gocd_open_alert,
+            catch_exceptions=False,
+            args=[
+                '--auth-token', 'XYZ',
+                '--responder', 'Some Team',
+            ],
+        )
+
+        assert script_run.exit_code == 0
+        mock_opsgenie_open.assert_called_once_with(
+            "[GoCD] Pipeline failed: edxapp",
+            (
+                "Pipeline edxapp failed.\n\n"
+                "- Runbook: <not provided>\n" # difference is here
+                "- Build logs: https://gocd.tools.edx.org/go/tab/build/detail/edxapp/123/build/456/prod\n"
+                "- Triggered by: Alice\n"
             ),
             'Some Team',
             alias='gocd-pipeline-edxapp-build-prod',


### PR DESCRIPTION
Supports https://github.com/edx/edx-arch-experiments/issues/1005

Also:

- Adjust alert message and description a bit
- Extract test environment for reuse