### PR TITLE
docs: Clean up GoCD alert script docs

### DIFF
--- a/tubular/scripts/gocd_close_alert.py
+++ b/tubular/scripts/gocd_close_alert.py
@@ -1,8 +1,14 @@
 """
 Command-line script to close any existing alert for a GoCD pipeline.
 
-This is like close_opsgenie_alert.py except it picks up pipeline details from
-environment variables to automatically create the alias field.
+Picks up pipeline details from GoCD environment variables to derive the alias
+field. (See `close_opsgenie_alert.py` for a version that allows full control
+of the alias.)
+
+This script is intended to be used with the "API - GoCD Integration" integration
+in Jira Service Management (previously Opsgenie):
+
+https://2u-internal.atlassian.net/jira/settings/products/ops/integrations/API/c15f0e6a-e15d-4659-ab1e-e0854c5fb5dc
 """
 
 import logging
@@ -19,15 +25,11 @@ log = logging.getLogger(__name__)
 @click.option(
     '--auth-token',
     required=True,
-    help="Authentication token to use for JSM Alerts API",
+    help="Integration API key to use for JSM Alerts API",
 )
 def gocd_close_alert(auth_token):
     """
-    Create an OpsGenie alert
-
-    Arguments:
-        auth_token: API token for Opsgenie/JSM
-        responders: The team responsible for the alert
+    Close a JSM alert, if it exists, using GoCD environment variables.
     """
     pipeline = os.environ['GO_PIPELINE_NAME']
     stage = os.environ['GO_STAGE_NAME']
@@ -37,7 +39,7 @@ def gocd_close_alert(auth_token):
     # the open alert will be discovered by its alias.
     alias = f'gocd-pipeline-{pipeline}-{stage}-{job}'
 
-    log.info(f"Closing alert {alias} on Opsgenie")
+    log.info(f"Closing alert in JSM with alias {alias}")
     opsgenie = opsgenie_api.OpsGenieAPI(auth_token)
     opsgenie.close_opsgenie_alert_by_alias(alias, source='tubular.scripts.gocd_close_alert')
 


### PR DESCRIPTION
- Link to integration that these need to be coordinated with
- Clarify what the auth token is
- Use "JSM" instead of "Opsgenie" everywhere (except to note the old name)
- Fix docstring of close-alert (which had been a copy of open-alert)
- Include alias in open-alert logging
- Add comment next to alias var explaining why it has to be of that form