### PR TITLE
fix: Remove broken script symlinks

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,8 @@
+# Old script symlinks
+
+This is where scripts used to live, but they now live under `tubular/scripts/`
+(and are installed as entry points via `setup.cfg`), and the symlinks point to
+the new locations to aid in migration.
+
+No new files should be added here, and old symlinks should be deleted once all
+callers have been updated to use the correct location.

--- a/scripts/close_opsgenie_alert.py
+++ b/scripts/close_opsgenie_alert.py
@@ -1,1 +1,0 @@
-../tubular/scripts/alert_opsgenie.py

--- a/scripts/find_and_advance_pipeline.py
+++ b/scripts/find_and_advance_pipeline.py
@@ -1,1 +1,0 @@
-../tubular/scripts/find_and_advance_pipeline.py

--- a/scripts/query_all_segment_deletion_requests.py
+++ b/scripts/query_all_segment_deletion_requests.py
@@ -1,1 +1,0 @@
-../tubular/scripts/query_all_segment_deletion_requests.py

--- a/scripts/validate_edp.py
+++ b/scripts/validate_edp.py
@@ -1,1 +1,0 @@
-../tubular/scripts/validate_edp.py


### PR DESCRIPTION
These symlinks either didn't go anywhere (due to typos) or went to the wrong place. (`close_opsgenie_alert.py` was the only one of the latter, and isn't used anywhere currently.)