### PR TITLE
feat:  adding commerce tools to retirement pipeline

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,13 +1,22 @@
+0x29a <demid@opencraft.com>
 Aarif <MrAarif@outlook.com>
 Aarif <mraarif@outlook.com>
+Abdou Seck <aseck@edx.org>
+Abdou Seck <djily02016@gmail.com>
 Adam Blackwell <adam@blackwell.ai>
 Adam Blackwell <adzuci@users.noreply.github.com>
 Adam Butterworth <abutterworth@edx.org>
+Adam Stankiewicz <agstanki@gmail.com>
+Adam Stankiewicz <astankiewicz@edx.org>
 Adeel Khan <muhammad.adeel@arbisoft.com>
+Adolfo R. Brandes <abrandes@tcril.org>
+Alex Dusenbery <alex.dusenbery@gmail.com>
 Awais Qureshi <awais.qureshi@arbisoft.com>
 Ben Holt <bholt+github@edx.org>
+Bernard Szabo <bszabo@edx.org>
 Bianca Severino <biancasev@gmail.com>
 Bianca Severino <bseverino@edx.org>
+Bilal Qamar <59555732+BilalQamar95@users.noreply.github.com>
 Bill DeRusha <bill.derusha@gmail.com>
 Bill DeRusha <bill@edx.org>
 Brandon Baker <bbaker6225@users.noreply.github.com>
@@ -15,6 +24,7 @@ Brandon Baker <bbaker@edx.org>
 Brian Beggs <bbeggs@edx.org>
 Brian Beggs <macdiesel@gmail.com>
 Brian Beggs <macdiesel@speakeasy.net>
+Brian Mesick <112640379+bmtcril@users.noreply.github.com>
 Brian Mesick <bmesick@edx.org>
 Calen Pennington <cale@edx.org>
 Calen Pennington <calen.pennington@gmail.com>
@@ -22,20 +32,34 @@ Chris Pappas <christopappas@users.noreply.github.com>
 Christie Rice <8483753+crice100@users.noreply.github.com>
 Cory Lee <cl10001123@gmail.com>
 Cory Lee <cory@edx.org>
+Daniel Nuzzo-Mueller <dnuzzo-mueller@2u.com>
 Dave Chamberlain <dchamberlain@edx.org>
 Dave St.Germain <dave@st.germa.in>
 Dave St.Germain <dstgermain@edx.org>
 David Ormsbee <dave@edx.org>
+Deborah Kaplan <deborahgu@users.noreply.github.com>
+Diana Huang <2952947+dianakhuang@users.noreply.github.com>
+Diana Huang <diana.k.huang@gmail.com>
 Diana Huang <dkh@edx.org>
 Dillon Dumesnil <ddumesnil@edx.org>
 Dillon Dumesnil <dillon.dumesnil@gmail.com>
 Dillon-Dumesnil <dillon.dumesnil@gmail.com>
 Douglas Hall <dhall@edx.org>
 Elton Carr, II <eltonc@microsoft.com>
+Feanil Patel <feanil@axim.org>
 Feanil Patel <feanil@edx.org>
+Feanil Patel <feanil@tcril.org>
 Fred Smith <derf@edx.org>
 Gregory Martin <greg@edx.org>
 Gregory Martin <yro@users.noreply.github.com>
+Hamza442 <56518775+Hamza442@users.noreply.github.com>
+Hamza442 <hamzakazmi43@gmail.com>
+Hassan <hassan.javeed84@gmail.com>
+Hassan <hassan@edx.org>
+Hassan Javeed <hassan@edx.org>
+Hassan Javeed <hjaveed@2u.com>
+Hunia Fatima <hunia.fatima@arbisoft.com>
+Hunia Fatima <huniafatima99@gmail.com>
 Isabel <isabelgk@users.noreply.github.com>
 J Eskew <jeskew@edx.org>
 Jansen Kantor <jkantor@edx.org>
@@ -48,34 +72,75 @@ Julia Eskew <julia.eskew@edx.org>
 Justin Hynes <jhynes@edx.org>
 Kevin Falcone <kevin@edx.org>
 Kevin Falcone <kevin@jibsheet.com>
+Kyle McCormick <kdmc@pm.me>
 Kyle McCormick <kdmccormick@wpi.edu>
+Kyle McCormick <kmccormick@edx.org>
+Kyle McCormick <kyle@axim.org>
 Luis Moreno <luis.moreno@edunext.co>
+M. Zulqarnain <muhammad.zulqarnain@arbisoft.com>
+Manjinder Singh <49171515+jinder1s@users.noreply.github.com>
+Matt Hughes <mhughes@2u.com>
 Matt Hughes <mhughes@edx.org>
 Matt Tuchfarber <matt@tuchfarber.com>
 Matt Tuchfarber <mtuchfarber@edx.org>
+Michael Terry <mterry@edx.org>
 Michael Youngstrom <myoungstrom@edx.org>
 Michael Youngstrom <youngstrom.m@husky.neu.edu>
 Mike Dikan <mike.dikan@gmail.com>
+Muhammad <muhammad.usama@arbisoft.com>
+Muhammad Abdullah Waheed <42172960+abdullahwaheed@users.noreply.github.com>
+Muhammad Abdullah Waheed <abdullah.waheed@arbisoft.com>
+Muhammad Soban Javed <58461728+iamsobanjaved@users.noreply.github.com>
+Muhammad Soban Javed <iamsobanjaved@gmail.com>
+Nadeem Shahzad <mshahzad@2u.com>
 Nadeem Shahzad <nadem.shahzad@gmail.com>
 Nadeem Shahzad <nshahzad@edx.org>
 Nathan Sprenkle <nsprenkle@users.noreply.github.com>
+Ned Batchelder <ned@nedbatchelder.com>
+Nicholas Moy <54609072+ohnickmoy@users.noreply.github.com>
+Rebecca Graber <rgraber@2u.com>
 Renzo Lucioni <renzo@lucioni.xyz>
+Robert Raposa <rraposa@edx.org>
+Saad Ali <NIXKnight@users.noreply.github.com>
+Saad Ali <saad.ali@arbisoft.com>
+Sarina Canelake <sarina@tcril.org>
 Sharon Wang <sharon.ran.wang@gmail.com>
+Simon Chen <schen@PC0HNHAJ.2tor.net>
 Simon Chen <schen@edx.org>
+Soban Javed <iamsobanjaved@gmail.com>
 Sofiya Semenova <sofiya@sofiya.io>
 Stu Young <estute@users.noreply.github.com>
 Stuart Young <syoung@edx.org>
 Syed Awais Ali <awaisalisabir@gmail.com>
+Syed Imran Hassan <45480841+syedimranhassan@users.noreply.github.com>
+Tim McCormack <tmccormack@edx.org>
 Troy Sankey <sankeytms@gmail.com>
 Troy Sankey <tsankey@edx.org>
+Usama Sadiq <usama.sadiq@arbisoft.com>
+UsamaSadiq <usama7274@gmail.com>
 Zia Fazal <zia.fazal@arbisoft.com>
+Zulqarnain <muhammad.zulqarnain@arbisoft.com>
 adeel khan <muhammad.adeel@arbisoft.com>
 bmedx <bmesick@edx.org>
+bszabo <bszabo@rcn.com>
 dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>
+dnuzz <dnuzzomueller@gmail.com>
+edX requirements bot <49161187+edx-requirements-bot@users.noreply.github.com>
+edX requirements bot <devops+edx-requirements-bot@edx.org>
+edX requirements bot <testeng+edx-requirements-bot@edx.org>
+farhan <mfarhan133@gmail.com>
 jansenk <jkantor@edx.org>
+k8 <kate.ruh@gmail.com>
+nadeemshahzad <mshahzad@2u.com>
+nadeemshahzad <nadem.shahzad@gmail.com>
 nadeemshahzad <nshahzad@edx.org>
+ohnickmoy <nmoy@edx.org>
+ruzniaiedm <ruzniaievdm@gmail.com>
+ruzniaievdm <ruzniaievdm@gmail.com>
 srwang <sharon.ran.wang@gmail.com>
 syed-awais-ali <aali@edx.org>
 syed-awais-ali <awaisalisabir@gmail.com>
 syedimranhassan <45480841+syedimranhassan@users.noreply.github.com>
 syedimranhassan <imran.hassan@arbisoft.com>
+toxinu <toxinu@gmail.com>
+usama101 <44398854+usama101@users.noreply.github.com>

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,247 @@
 CHANGES
 =======
 
-* escape salesforce api queries
+* chore: readme fixes
+* chore: undeprecating retirement
+* Revert "chore: reinstating tubular to prod-ready for retirement"
+* chore: manual pip install
+* chore: manual pip install
+* chore: manual pip install
+* chore: manual pip install
+* chore: new dockerfile
+* chore:  missing import
+* chore: modified non-retirement scripts  for package update
+* chore: reinstating tubular to prod-ready for retirement
+* fix: Remove broken script symlinks (#36)
+* docs: Clean up GoCD alert script docs (#35)
+* feat: Include stage and job in alert name in GoCD alerting (#34)
+* feat: Add runbook option to gocd alert script (#33)
+* feat: Prevent empty responder value in GoCD alert script (#32)
+* feat: Add GoCD-specific Opsgenie alerting scripts (#30)
+* build: Fix tubular CI by upgrading to supported Ubuntu runner version (#31)
+* build: Post-fork changes (#29)
+* Datadog synthetic tests (authoring pipeline) on prod (#28)
+* Revert "Fix datadog secrets for testing pipeline (#26)"
+* Fix datadog secrets for testing pipeline (#26)
+* feat: Trigger tests pipeline diagnostic (#25)
+* feat: added test cases for feature flags entry
+* fix: added test cases for feature flags keys
+* feat: Course authoring test config comes from GoCD pipeline (#22)
+* Bszabo/frontend app authoring pipeline testing (#21)
+* chore: unifiying feature flags env config
+* chore: adding feature flags json list in env variables
+* fix: Add timeout to retrieve\_latest\_base\_ami.py
+* chore: Added pagerduty close alert script
+* chore: Added pagerduty alert script
+* chore: pin cloudflare and moto version
+* chore: Upgrade Python requirements
+* chore: Remove npm version pinning and use global npm for alias installation (#14)
+* fix: handle updated edge case in test cases
+* fix: fix github\_api to consider commits without checks as passing
+* feat: Add runbook hint to merge\_approved\_prs.py (#13)
+* chore: always return tuple in \_upload\_js\_sourcemaps\_config (#10)
+* chore: remove temp debug logs (#9)
+* chore: remove cwd from datadog-ci sourcemaps upload (#8)
+* chore: add debug logging to datadog sourcemaps upload (#7)
+* fix: provide --project-path command arg to datadog-ci when uploading JS sourcemaps (#6)
+* fix: correctly format the command args for datadog-ci (#5)
+* chore: introduce support for NPM\_DEPLOY config for MFEs wrt uploading JS source maps to Datadog (#4)
+* feat: upload source maps to Datadog during MFE deploy (#3)
+* chore: set ci fail flag for codecov to false
+* fix: fixed failing test
+* feat: expose APP\_VERSION env var with HEAD commit sha
+* feat: install npm private requirements during frontend build (#1)
+* docs: Remove Open edX references
+* docs: Note new ownership of repo
+* feat: Deprecate the structures script
+* chore: Fix imports
+* chore: Update readme
+* chore: Deprecate the user-retirement scripts that are migrated within edx-platform repo
+* fix: add retry for sending slack messages (#730)
+* fix: add callback method (#723)
+* fix: import backoff (#722)
+* feat: add retry when fetching current image (#720)
+* docs: Update the security e-mail address
+* fix: Replaced whitelist\_externals with allowlist\_externals in tox and removed tox-battery
+* feat: GoCD agent config from templates ISRE-2015
+* fix: Pin google-api-python-client under 2.0
+* fix: Update mock data for google library > 1.7.5
+* chore: Unpin tubular requirements, make upgrade
+* fix: remove future dependency
+* chore: Updating Python Requirements
+* fix: Default to Ubuntu 20.04 Focal, remove xenial
+* fix: Retry deleting a branch if GitHub says it's unknown
+* fix: Use a longer SHA prefix to avoid collisions (just a precaution)
+* feat: close alerts from opsgenie api (#679)
+* docs: update 2U/edX release notices (#675)
+* chore: Unpin and upgrade cloudflare library
+* chore: Updating Python Requirements
+* fix: Correct filter inputs
+* chore: fixing import order to fix retirement job. (#672)
+* Revert "Use 'npm ci' instead of 'npm install'"
+* chore: upgrading boto3 and botocore versions. (#666)
+* test: fixing tests as per new moto version. (#663)
+* fix: remove boto package from ec2 tests
+* chore: clear out remnants of boto
+* fix: remove toxenv
+* fix: update tox.ini for coverage report
+* chore: upgrade requirements
+* fix: add codecov.yml
+* fix: cut down on tox env
+* feat: add codecov to tubular repo
+* chore: removed un-used script
+* Fixing asgrard (#655)
+* Fixing s3 files (#656)
+* Fixing tests for ec2 (#647)
+* feat: update how auth to hubspot api is done
+* feat: remove old unused command using boto (not boto3)
+* docs: Update the contributing guidelines link
+* chore: Updating Python Requirements
+* fix: Add resource type to tags
+* fix: Fix spelling of tag parameter
+* fix: Pass through a list instead of a set
+* fix: Fix elb pagination call
+* fix: errant boto2 syntax
+* fix: remove old code from asg deployment
+* fix: Fix cleanup\_asgs for boto3
+* fix: elb-related deployment code boto3-ification
+* fix: Fix usage of old name
+* fix: add boto3 to more function calls
+* fix: Convert ASG code to use boto3
+* fix: unit test was out of date
+* fix: upgrade and unit tests
+* chore: Allow retirement redrive
+* chore: update tests and change error output
+* chore: Improve doc string
+* feat: Clarify mergeback PR description (#624)
+* feat!: Allow choosing deployment tag's name when merged private PRs (#622)
+* feat: Remove now-unused scripts relating to edxapp deployments (#620)
+* fix: fix 401 unauthorized error in user retirement amplitude\_api
+* feat: user retirement from Amplitdue integrated to user\_retirement script
+* build: Updating a missing workflow file \`add-depr-ticket-to-depr-board.yml\`
+* build: Creating a missing workflow file \`add-remove-label-on-comment.yml\`
+* build: Creating a missing workflow file \`self-assign-issue.yml\`
+* chore: Add test for user limit
+* chore(api update): Support new limit parameter for get\_learners\_to\_retire
+* fix: some repos disabled the \`allow\_merge\_commit\`. Using squash metho… (#609)
+* refactor: switched to ci to install dependencies
+* chore: add retrieve base ami script
+* chore: Add new CLI options for retire user actions
+* fix: Increased number of records per page to 100. (#602)
+* Add new option to prune batch size and change defaults for max size
+* feat: add flag to check all PR checks status
+* feat: Adding new script to get all open prs with ready to merge label
+* fix: adding new method to fetch all check runs by commit. (#591)
+* fix: fixing upgrade requirements. (#592)
+* fix: tox failures due to multiple package-looking directories
+* fix: Pin tox because it broke our tests
+* chore: update GDPR Email Template Learner
+* fix: Test broken by pruner fix
+* refactor: Early exit if missing structures
+* feat: Add --dump-structures option for debugging
+* refactor: Rename option for missing structures
+* feat: Improve logging of missing structures
+* feat: More output for missing ids
+* fix: Move debug logging so relink is accurate
+* refactor: Use list comprehension
+* refactor: Exit on missing structures
+* feat: Add more debug logging
+* refactor: Improve code quality
+* fix: Prevent crash if id doesn't exist
+* feat: Add force option for missing structures
+* fix: Log missing structures ISRE-1377
+* fix: Stop crashing on non existent id ISRE-1377
+* fix: slack bot authentication for GoCD notifications
+* Revert attempts to log slack api responses
+* fix: typo in slack message logging
+* fix: don't swallow errors returned from the slack api
+* fix: The error logging for FrontendBuilder object needs two arguments supplied. Fix the bug where in the FrontendBuilder object, there are logging statements only supplied 1 argument. Supply 2 arguments instead
+* fix: Duplicate checking blocking unique messages
+* feat: Add logging when skipping due to duplicate
+* feat: Add --force option to message\_prs\_in\_range
+* fix: update path to .github workflows to read from openedx org
+* fix: fix github url strings (org edx -> openedx)
+* chore: run \`edx\_lint\` update with the current version of the repo
+* fix: Send correct data to retirement partner report
+* chore: pin npm@8
+* refactor: Remove EdxRestApiClient usage in tubular
+* fix: change e2e troubleshooting slack channel (#571)
+* fix: handle ConnectionError from the edX API
+* Revert "fix: Publish release pages to 2u-internal wiki, not openedx (#566)" (#568)
+* build: Stop testing on Python 3.6 and 3.7 (#567)
+* fix: Publish release pages to 2u-internal wiki, not openedx (#566)
+* chore: Update DriveApi to add suppport for user accounts
+* Revert "FC-0001: Remove EdxRestApiClient usage in tubular"
+* refactor: Remove EdxRestApiClient usage in tubular
+* Revert "FC-0001: Remove EdxRestApiClient usage in tubular"
+* Revert "chore: Fix import error."
+* chore: Fix import error
+* refactor: Remove EdxRestApiClient usage in tubular
+* fix: reduced batch size due to userRateLimitExceeded
+* docs: Add description to temporary .github/ISSUE\_TEMPLATE files
+* build: add DEPR workflow automation & default issue overrides
+* feat: Add requirements upgrade workflow
+* feat: Remove \`--source-branch\` from merge-approved-prs (#549)
+* feat: Allow specifying source commit in merge-PRs; rm unused --sha option (#548)
+* chore: Move testing requirments out of setup file
+* fix: Don't try to merge security patches when there aren't any (#546)
+* chore: upgrading tubular to py3.8
+* chore: upgrade tubular to Py 3.8
+* feat: Add logging to diagnose race condition and branch behavior (#545)
+* fix: fix tubualr tests
+* fix: Make logging actually work
+* build: use the organization commitlint check
+* chore: edX API client: Added retry on ConnectionError(104)
+* fix: add sleep to calls to batches of users in user retirement archiver
+* fix: disable debug s3 logging in retirement archiver
+* fix: add raw prefix to s3 path for user retirements
+* Change retirement archive to use the Jenkins AWS assumed role
+* fix: improve logging in retirement archiver script
+* feat: script errors and exits if wrong version (#533)
+* fix: update PyGitHub to a version that doesn't use use\_2to3
+* feat: add cli params to retirement\_archive\_and\_cleanup script for testing and debugging
+* Update python requirements
+* fix: remove unnecessary logs (#527)
+* feat: adding loging to git pushes (#526)
+* Update k8s script
+* Updated opsgenie script to accept responders as param
+* Updated gocd script
+* Adding script to update and check config repo
+* feat!: explicitly limit types of frontend config values
+* test: add some cursory tests for frontend building
+* fix: make frontend\_build handle numeric/bool config values again
+* style: use f-strings in frontend\_build.py
+* fix: wrap frontend config override values in quotes
+* feat!: Remove WIP Modulestore pruning code
+* Bump pyyaml from 5.1 to 5.4 in /requirements
+* Fixing symlinks (#518)
+* Adding automation for pipeline\_group\_acls (#517)
+* chore: Remove the Sailthru retirement stage
+* Enable release tagging
+* fix: re-add python 3.6 support (for GoCD)
+* chore: update CI to test python 3.7, 3.8, remove 3.5
+* fix: switch send\_email to use boto3
+* fix: remove --no-index from pip-compile call, and run make upgrade
+* Revert "Merge pull request #509 from edx/aali/PSRE-594\_no\_comments\_on\_closed\_prs" (#511)
+* do not add comments on closed PRs
+* do not add comments on closed PRs
+* Added script to create k8s job
+* Added support for specifying multiple partners
+* Jkantor/escape salesforce query (#500)
+* fix: remove global flag on npm install
+* fix: pin npm@6
+* ISRE-618 | Delete 0 Instance ASGs during deploy step  if they are created (#496)
+* Revert "Python Code Cleanup (#493)" (#497)
+* Python Code Cleanup (#493)
+* AA-595: Add script to delete Braze user information
+* Added HTTP code
+* Update permission and add logging
+* Link opsgenie script
+* Link opsgenie script
+* Reduce rate limit confusion/red herrings
+* Log failed repo when github throws 404 exception
+* Throw an exception upon error that is caught in backoff decorator
+* Removing update recent deployers related code (#487)
 * Revert "Revert "Upgrade moto > 1.0.0, unpin testing dependencies for edx\_lint (#480)" (#484)" (#485)
 * Revert "Upgrade moto > 1.0.0, unpin testing dependencies for edx\_lint (#480)" (#484)
 * Remove calls to method that does not exist (#483)

--- a/tubular/edx_api.py
+++ b/tubular/edx_api.py
@@ -496,3 +496,17 @@ class LicenseManagerApi(BaseApiClient):
         except HttpDoesNotExistException:
             LOG.info("No license manager data found for user")
             return True
+
+class CommerceCoordinatorApi(BaseApiClient):
+    """
+    Commerce-Coordinator API client.
+    """
+    @_retry_lms_api()
+    def retire_learner(self, learner):
+        """
+        Performs the learner retirement step for Commerce-Coordinator.
+        Passes the learner's LMS User Id instead of username.
+        """
+        data = {'edx_lms_user_id': learner['user']['id']}
+        api_url = self.get_api_url('lms/user_retirement')
+        return self._request('POST', api_url, json=data)

--- a/tubular/scripts/helpers.py
+++ b/tubular/scripts/helpers.py
@@ -21,8 +21,13 @@ from six import text_type
 # Add top-level module path to sys.path before importing tubular code.
 sys.path.append(path.dirname(path.dirname(path.abspath(__file__))))
 
-from tubular.edx_api import CredentialsApi, EcommerceApi, LicenseManagerApi, \
-    LmsApi  # pylint: disable=wrong-import-position
+from tubular.edx_api import (
+    CommerceCoordinatorApi,
+    CredentialsApi,
+    EcommerceApi,
+    LicenseManagerApi,
+    LmsApi,
+)
 from tubular.braze_api import BrazeApi  # pylint: disable=wrong-import-position
 from tubular.segment_api import SegmentApi  # pylint: disable=wrong-import-position
 from tubular.salesforce_api import SalesforceApi  # pylint: disable=wrong-import-position
@@ -153,6 +158,7 @@ def _setup_all_apis_or_exit(fail_func, fail_code, config):
         credentials_base_url = config['base_urls'].get('credentials', None)
         segment_base_url = config['base_urls'].get('segment', None)
         license_manager_base_url = config['base_urls'].get('license_manager', None)
+        commerce_coordinator_base_url = config['base_urls'].get('commerce_coordinator', None)
         client_id = config['client_id']
         client_secret = config['client_secret']
         braze_api_key = config.get('braze_api_key', None)
@@ -179,6 +185,7 @@ def _setup_all_apis_or_exit(fail_func, fail_code, config):
                     ('CREDENTIALS', credentials_base_url),
                     ('SEGMENT', segment_base_url),
                     ('HUBSPOT', hubspot_api_key),
+                    ('COMMERCE_COORDINATOR', commerce_coordinator_base_url),
             ):
                 if state[2] == service and service_url is None:
                     fail_func(fail_code, 'Service URL is not configured, but required for state {}'.format(state))
@@ -233,6 +240,14 @@ def _setup_all_apis_or_exit(fail_func, fail_code, config):
                 segment_base_url,
                 segment_auth_token,
                 segment_workspace_slug
+            )
+
+        if commerce_coordinator_base_url:
+            config['COMMERCE_COORDINATOR'] = CommerceCoordinatorApi(
+                lms_base_url,
+                commerce_coordinator_base_url,
+                client_id,
+                client_secret,
             )
     except Exception as exc:  # pylint: disable=broad-except
         fail_func(fail_code, 'Unexpected error occurred!', exc)

--- a/tubular/tests/test_edx_api.py
+++ b/tubular/tests/test_edx_api.py
@@ -522,3 +522,41 @@ class TestLicenseManagerApi(OAuth2Mixin, unittest.TestCase):
                 original_username=FAKE_ORIGINAL_USERNAME
             )
         )
+
+class TestCommerceCoordinatorApi(OAuth2Mixin, unittest.TestCase):
+    """
+    Test the edX Commerce-Coordinator API client.
+    """
+
+    @responses.activate(registry=OrderedRegistry)
+    def setUp(self):
+        super().setUp()
+        self.mock_access_token_response()
+        self.lms_base_url = 'http://localhost:18000/'
+        self.commerce_coordinator_base_url = 'http://localhost:8140/'
+        self.commerce_coordinator_api = edx_api.CommerceCoordinatorApi(
+            self.lms_base_url,
+            self.commerce_coordinator_base_url,
+            'the_client_id',
+            'the_client_secret'
+        )
+
+    @patch.object(edx_api.CommerceCoordinatorApi, '_request')
+    def test_retire_learner(self, mock_request):
+        learner_data = get_fake_user_retirement()
+        json_data = {
+            'edx_lms_user_id': learner_data['user']['id']
+        }
+        responses.add(
+            POST,
+            urljoin(self.commerce_coordinator_base_url, 'lms/user_retirement'),
+            match=[matchers.json_params_matcher(json_data)]
+        )
+
+        self.commerce_coordinator_api.retire_learner(learner=learner_data)
+
+        mock_request.assert_called_once_with(
+            'POST',
+            urljoin(self.commerce_coordinator_base_url, 'lms/user_retirement/'),
+            json=json_data
+        )


### PR DESCRIPTION
This takes @JadeyOlivier's changes from https://github.com/openedx/edx-platform/pull/35203 (reverted) into tubular, which is now running the 2U retirement pipeline. This should enable retiring from CommerceTools.

FIXES: APER-3984