### PR TITLE
chore: fixing rv retirements bug

### DIFF
--- a/tubular/red_ventures_api.py
+++ b/tubular/red_ventures_api.py
@@ -79,7 +79,7 @@ class RedVenturesApi:
             "Content-Type": "application/json",
         }
 
-        email = user["user"].get("original_email", None)
+        email = user.get("original_email", None)
         if not email:
             raise TypeError(
                 "Expected an email address for user to delete, but received None."

--- a/tubular/tests/test_red_ventures.py
+++ b/tubular/tests/test_red_ventures.py
@@ -27,7 +27,20 @@ class TestRedVentures(unittest.TestCase):
 
     def setUp(self):
         super().setUp()
-        self.user = {"user": {"id": "1234", "original_email": "fonzie@example.com"}}
+        self.user = {
+            "id": 425497,
+            "user": {
+                "id": 64298028,
+                "username": "fonzie",
+                "email": "retired__user_8675309@retired.invalid",
+                "profile": {"id": 8675309, "name": "Arthur Fonzarelli"},
+            },
+            "original_username": "fonzie",
+            "original_email": "fonzie@example.com",
+            "original_name": "Arthur Fonzarelli",
+            "retired_username": "retired__user_8675309",
+            "retired_email": "retired__user_8675309@retired.invalid",
+        }
         self.red_ventures = RedVenturesApi(
             "test_audience",
             "https://test_auth_url",


### PR DESCRIPTION
Barring end-to-end tests, I'm relying on mocked return data. To prevent further errors here, I've replaced the mock stubbed out value with one made by taking a real value and replacing real user data. There's enough layers of object nesting that I believe I made multiple errors on the manual stub.