### PR TITLE
feat: Implement Salesforce Marketing Cloud API for user deletion

### DIFF
--- a/tubular/salesforce_marketing_cloud_api.py
+++ b/tubular/salesforce_marketing_cloud_api.py
@@ -1,0 +1,207 @@
+"""
+Salesforce Marketing Cloud API class that is used to delete user from SFMC.
+"""
+
+import logging
+import os
+
+import backoff
+import requests
+
+logger = logging.getLogger(__name__)
+MAX_ATTEMPTS = int(os.environ.get("RETRY_SFMC_MAX_ATTEMPTS", 5))
+
+
+class SalesforceMarketingCloudException(Exception):
+    """
+    SalesforceMarketingCloudException will be raised when there is a fatal error and is not recoverable.
+    """
+
+    pass
+
+
+class SalesforceMarketingCloudRecoverableException(SalesforceMarketingCloudException):
+    """
+    SalesforceMarketingCloudRecoverableException will be raised when request can be retryable.
+    """
+
+    pass
+
+
+class SalesforceMarketingCloudApi:
+    """
+    Salesforce Marketing Cloud API is used to handle communication with SFMC APIs.
+    """
+
+    def __init__(
+        self,
+        client_id: str,
+        client_secret: str,
+        subdomain: str,
+        account_id: str,
+    ):
+        """
+        Initialize the SFMC API client.
+
+        Args:
+            client_id: SFMC OAuth client ID
+            client_secret: SFMC OAuth client secret
+            subdomain: SFMC subdomain (e.g., 'mc123456789')
+            account_id: SFMC account/MID identifier
+        """
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.subdomain = subdomain
+        self.account_id = account_id
+        self.token_host = f"{subdomain}.auth.marketingcloudapis.com"
+        self.suppression_host = f"{subdomain}.rest.marketingcloudapis.com"
+        self._access_token = None
+
+    @backoff.on_exception(
+        backoff.expo,
+        SalesforceMarketingCloudRecoverableException,
+        max_tries=MAX_ATTEMPTS,
+    )
+    def _get_access_token(self) -> str:
+        """
+        Obtain an OAuth access token from SFMC.
+
+        Returns:
+            str: Access token for API requests
+
+        Raises:
+            SalesforceMarketingCloudException: if the error from SFMC is unrecoverable/unretryable.
+            SalesforceMarketingCloudRecoverableException: if the error from SFMC is recoverable/retryable.
+        """
+        token_url = f"https://{self.token_host}/v2/token"
+        token_data = {
+            "grant_type": "client_credentials",
+            "client_id": self.client_id,
+            "client_secret": self.client_secret,
+        }
+        token_headers = {"Content-Type": "application/json"}
+
+        try:
+            response = requests.post(
+                token_url, headers=token_headers, json=token_data, timeout=30
+            )
+
+            if response.status_code == 200:
+                return response.json()["access_token"]
+
+            error_msg = (
+                f"SFMC token request failed with status {response.status_code}: "
+                f"{response.reason}"
+            )
+
+            # Retry on rate limiting or server errors
+            if response.status_code == 429 or 500 <= response.status_code < 600:
+                logger.warning(error_msg)
+                raise SalesforceMarketingCloudRecoverableException(error_msg)
+            else:
+                logger.error(error_msg)
+                raise SalesforceMarketingCloudException(error_msg)
+
+        except requests.exceptions.RequestException as exc:
+            error_msg = f"SFMC token request failed with exception: {str(exc)}"
+            logger.error(error_msg)
+            raise SalesforceMarketingCloudRecoverableException(error_msg)
+
+    @backoff.on_exception(
+        backoff.expo,
+        SalesforceMarketingCloudRecoverableException,
+        max_tries=MAX_ATTEMPTS,
+    )
+    def delete_user(self, user: dict) -> None:
+        """
+        Delete a user from Salesforce Marketing Cloud by marking them for deletion.
+
+        This method sends a request to SFMC to add the user's subscriber key to the
+        deletion data extension, marking them for removal.
+
+        Args:
+            user (dict): User data containing 'user' key with 'id' field (LMS user ID)
+
+        Raises:
+            TypeError: if user ID is not provided
+            SalesforceMarketingCloudException: if the error from SFMC is unrecoverable/unretryable.
+            SalesforceMarketingCloudRecoverableException: if the error from SFMC is recoverable/retryable.
+        """
+        # Extract user ID from the learner dict
+        user_id = None
+        if isinstance(user, dict):
+            user_data = user.get("user", {})
+            if isinstance(user_data, dict):
+                user_id = user_data.get("id")
+            else:
+                user_id = user_data
+
+        if not user_id:
+            raise TypeError(
+                "Expected a user ID for user to delete, but received None."
+            )
+
+        # Convert user_id to string for the API
+        subscriber_key = str(user_id)
+
+        # Get access token
+        access_token = self._get_access_token()
+
+        # Prepare deletion request
+        suppression_route = "hub/v1/dataevents/key:Contacts_for_Delete/rowset"
+        suppress_url = f"https://{self.suppression_host}/{suppression_route}"
+        suppress_headers = {
+            "Authorization": f"Bearer {access_token}",
+            "Content-Type": "application/json",
+        }
+
+        suppress_data = [
+            {
+                "keys": {"Subscriberkey": subscriber_key},
+                "values": {"IsDelete": "True"},
+            }
+        ]
+
+        try:
+            response = requests.post(
+                suppress_url,
+                headers=suppress_headers,
+                json=suppress_data,
+                timeout=30,
+            )
+
+            if response.status_code == 200:
+                logger.info(
+                    f"SFMC user deletion succeeded for subscriber key: {subscriber_key}"
+                )
+                return
+
+            # Parse error response
+            error_msg = (
+                f"SFMC user deletion failed with status {response.status_code}: "
+                f"{response.reason}"
+            )
+
+            try:
+                error_details = response.json()
+                if error_details:
+                    error_msg += f" - Details: {error_details}"
+            except ValueError:
+                # Response is not JSON
+                pass
+
+            # Retry on rate limiting or server errors
+            if response.status_code == 429 or 500 <= response.status_code < 600:
+                logger.warning(error_msg)
+                raise SalesforceMarketingCloudRecoverableException(error_msg)
+            else:
+                logger.error(error_msg)
+                raise SalesforceMarketingCloudException(error_msg)
+
+        except requests.exceptions.RequestException as exc:
+            error_msg = (
+                f"SFMC user deletion failed with exception for subscriber key "
+                f"{subscriber_key}: {str(exc)}"
+            )
+            logger.error(error_msg)
+            raise SalesforceMarketingCloudRecoverableException(error_msg)

--- a/tubular/salesforce_marketing_cloud_api.py
+++ b/tubular/salesforce_marketing_cloud_api.py
@@ -1,5 +1,5 @@
 """
-Salesforce Marketing Cloud API class that is used to delete user from SFMC.
+Salesforce Marketing Cloud API class that is used to delete a user from SFMC.
 """
 
 import logging
@@ -14,7 +14,7 @@ MAX_ATTEMPTS = int(os.environ.get("RETRY_SFMC_MAX_ATTEMPTS", 5))
 
 class SalesforceMarketingCloudException(Exception):
     """
-    SalesforceMarketingCloudException will be raised when there is a fatal error and is not recoverable.
+    SalesforceMarketingCloudException will be raised when a fatal, non-recoverable error occurs.
     """
 
     pass
@@ -22,7 +22,7 @@ class SalesforceMarketingCloudException(Exception):
 
 class SalesforceMarketingCloudRecoverableException(SalesforceMarketingCloudException):
     """
-    SalesforceMarketingCloudRecoverableException will be raised when request can be retryable.
+    SalesforceMarketingCloudRecoverableException will be raised when the request can be retried.
     """
 
     pass
@@ -38,7 +38,6 @@ class SalesforceMarketingCloudApi:
         client_id: str,
         client_secret: str,
         subdomain: str,
-        account_id: str,
     ):
         """
         Initialize the SFMC API client.
@@ -47,12 +46,10 @@ class SalesforceMarketingCloudApi:
             client_id: SFMC OAuth client ID
             client_secret: SFMC OAuth client secret
             subdomain: SFMC subdomain (e.g., 'mc123456789')
-            account_id: SFMC account/MID identifier
         """
         self.client_id = client_id
         self.client_secret = client_secret
         self.subdomain = subdomain
-        self.account_id = account_id
         self.token_host = f"{subdomain}.auth.marketingcloudapis.com"
         self.suppression_host = f"{subdomain}.rest.marketingcloudapis.com"
 
@@ -125,19 +122,8 @@ class SalesforceMarketingCloudApi:
             SalesforceMarketingCloudException: if the error from SFMC is unrecoverable/unretryable.
             SalesforceMarketingCloudRecoverableException: if the error from SFMC is recoverable/retryable.
         """
-        user_id = None
-        if isinstance(user, dict):
-            user_data = user.get("user", {})
-            if isinstance(user_data, dict):
-                user_id = user_data.get("id")
-            else:
-                user_id = user_data
-
-        if not user_id:
-            raise TypeError(
-                "Expected a user ID for user to delete, but received None."
-            )
-
+        # Extract user ID - expects format: {'user': {'id': 1234}}
+        user_id = user['user']['id']
         subscriber_key = str(user_id)
 
         access_token = self._get_access_token()

--- a/tubular/scripts/helpers.py
+++ b/tubular/scripts/helpers.py
@@ -33,6 +33,7 @@ from tubular.braze_api import BrazeApi  # pylint: disable=wrong-import-position
 from tubular.hubspot_api import HubspotAPI  # pylint: disable=wrong-import-position
 from tubular.red_ventures_api import RedVenturesApi  # pylint: disable=wrong-import-position
 from tubular.salesforce_api import SalesforceApi  # pylint: disable=wrong-import-position
+from tubular.salesforce_marketing_cloud_api import SalesforceMarketingCloudApi  # pylint: disable=wrong-import-position
 from tubular.segment_api import SegmentApi  # pylint: disable=wrong-import-position
 
 
@@ -182,6 +183,10 @@ def _setup_all_apis_or_exit(fail_func, fail_code, config):
         red_ventures_audience = config.get('red_ventures_audience', None)
         red_ventures_auth_url = config.get('red_ventures_auth_url', None)
         red_ventures_deletion_url = config.get('red_ventures_deletion_url', None)
+        salesforce_marketing_cloud_client_id = config.get('salesforce_marketing_cloud_client_id', None)
+        salesforce_marketing_cloud_secret = config.get('salesforce_marketing_cloud_secret', None)
+        salesforce_marketing_cloud_subdomain = config.get('salesforce_marketing_cloud_subdomain', None)
+        salesforce_marketing_cloud_account_id = config.get('salesforce_marketing_cloud_account_id', None)
 
         for state in config['retirement_pipeline']:
             for service, service_url in (
@@ -193,6 +198,7 @@ def _setup_all_apis_or_exit(fail_func, fail_code, config):
                     ('HUBSPOT', hubspot_api_key),
                     ('COMMERCE_COORDINATOR', commerce_coordinator_base_url),
                     ('RED_VENTURES', red_ventures_auth_url),
+                    ('SALESFORCE_MARKETING_CLOUD', salesforce_marketing_cloud_client_id),
             ):
                 if state[2] == service and service_url is None:
                     fail_func(fail_code, 'Service URL is not configured, but required for state {}'.format(state))
@@ -264,6 +270,14 @@ def _setup_all_apis_or_exit(fail_func, fail_code, config):
                 red_ventures_deletion_url,
                 red_ventures_username,
                 red_ventures_password,
+            )
+
+        if salesforce_marketing_cloud_client_id:
+            config['SALESFORCE_MARKETING_CLOUD'] = SalesforceMarketingCloudApi(
+                salesforce_marketing_cloud_client_id,
+                salesforce_marketing_cloud_secret,
+                salesforce_marketing_cloud_subdomain,
+                salesforce_marketing_cloud_account_id,
             )
     except Exception as exc:  # pylint: disable=broad-except
         fail_func(fail_code, 'Unexpected error occurred!', exc)

--- a/tubular/scripts/helpers.py
+++ b/tubular/scripts/helpers.py
@@ -186,7 +186,6 @@ def _setup_all_apis_or_exit(fail_func, fail_code, config):
         salesforce_marketing_cloud_client_id = config.get('salesforce_marketing_cloud_client_id', None)
         salesforce_marketing_cloud_secret = config.get('salesforce_marketing_cloud_secret', None)
         salesforce_marketing_cloud_subdomain = config.get('salesforce_marketing_cloud_subdomain', None)
-        salesforce_marketing_cloud_account_id = config.get('salesforce_marketing_cloud_account_id', None)
 
         for state in config['retirement_pipeline']:
             for service, service_url in (
@@ -277,7 +276,6 @@ def _setup_all_apis_or_exit(fail_func, fail_code, config):
                 salesforce_marketing_cloud_client_id,
                 salesforce_marketing_cloud_secret,
                 salesforce_marketing_cloud_subdomain,
-                salesforce_marketing_cloud_account_id,
             )
     except Exception as exc:  # pylint: disable=broad-except
         fail_func(fail_code, 'Unexpected error occurred!', exc)

--- a/tubular/tests/test_salesforce_marketing_cloud.py
+++ b/tubular/tests/test_salesforce_marketing_cloud.py
@@ -1,0 +1,118 @@
+"""
+Tests for the Salesforce Marketing Cloud API functionality
+"""
+
+import ddt
+import os
+import logging
+import unittest
+from unittest import mock
+
+import requests_mock
+
+os.environ['RETRY_SFMC_MAX_ATTEMPTS'] = '2'
+from tubular.salesforce_marketing_cloud_api import (
+    SalesforceMarketingCloudApi,
+    SalesforceMarketingCloudException,
+    SalesforceMarketingCloudRecoverableException,
+)
+
+
+@ddt.ddt
+@requests_mock.Mocker()
+class TestSalesforceMarketingCloud(unittest.TestCase):
+    """
+    Class containing tests of all code interacting with Salesforce Marketing Cloud.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.learner = {'user': {'id': 1234}}
+        self.sfmc = SalesforceMarketingCloudApi(
+            'test-client-id',
+            'test-client-secret',
+            'test-subdomain',
+            'test-account-id'
+        )
+        self.token_url = 'https://test-subdomain.auth.marketingcloudapis.com/v2/token'
+        self.delete_url = 'https://test-subdomain.rest.marketingcloudapis.com/hub/v1/dataevents/key:Contacts_for_Delete/rowset'
+        self.access_token = 'test-access-token-12345'
+
+    def _mock_token_request(self, req_mock, status_code=200, access_token=None):
+        if access_token is None:
+            access_token = self.access_token
+        
+        req_mock.post(
+            self.token_url,
+            json={'access_token': access_token} if status_code == 200 else {},
+            status_code=status_code
+        )
+
+    def _mock_delete_request(self, req_mock, status_code=200, response_json=None):
+        req_mock.post(
+            self.delete_url,
+            json=response_json if response_json else {},
+            status_code=status_code
+        )
+
+    def test_delete_user_happy_path(self, req_mock):
+        self._mock_token_request(req_mock)
+        self._mock_delete_request(req_mock, 200)
+
+        logger = logging.getLogger('tubular.salesforce_marketing_cloud_api')
+        with mock.patch.object(logger, 'info') as mock_info:
+            self.sfmc.delete_user(self.learner)
+
+        self.assertTrue(mock_info.called)
+        self.assertIn('SFMC user deletion succeeded', str(mock_info.call_args))
+        self.assertIn('1234', str(mock_info.call_args))
+
+        self.assertEqual(len(req_mock.request_history), 2)
+        
+        token_request = req_mock.request_history[0]
+        self.assertEqual(token_request.json(), {
+            'grant_type': 'client_credentials',
+            'client_id': 'test-client-id',
+            'client_secret': 'test-client-secret'
+        })
+
+        delete_request = req_mock.request_history[1]
+        self.assertEqual(delete_request.headers['Authorization'], f'Bearer {self.access_token}')
+        request_data = delete_request.json()[0]
+        self.assertEqual(request_data['keys']['SubscriberKey'], '1234')
+        self.assertIs(request_data['values']['IsDelete'], True)
+
+    def test_delete_user_missing_user_id(self, req_mock):
+        learner = {'user': {}}
+        
+        with self.assertRaises(TypeError) as exc:
+            self.sfmc.delete_user(learner)
+        
+        self.assertEqual(
+            str(exc.exception),
+            'Expected a user ID for user to delete, but received None.'
+        )
+
+    def test_delete_fatal_error(self, req_mock):
+        self._mock_token_request(req_mock)
+        self._mock_delete_request(req_mock, status_code=400, response_json={'error': 'Bad Request'})
+
+        logger = logging.getLogger('tubular.salesforce_marketing_cloud_api')
+        with mock.patch.object(logger, 'error') as mock_error:
+            with self.assertRaises(SalesforceMarketingCloudException):
+                self.sfmc.delete_user(self.learner)
+
+        self.assertTrue(mock_error.called)
+        error_message = str(mock_error.call_args)
+        self.assertIn('SFMC user deletion failed', error_message)
+        self.assertIn('400', error_message)
+
+    @ddt.data(429, 500)
+    def test_delete_recoverable_error(self, status_code, req_mock):
+        self._mock_token_request(req_mock)
+        self._mock_delete_request(req_mock, status_code=status_code)
+
+        with self.assertRaises(SalesforceMarketingCloudRecoverableException):
+            self.sfmc.delete_user(self.learner)
+
+        self.assertGreaterEqual(len(req_mock.request_history), 2)

--- a/tubular/tests/test_salesforce_marketing_cloud.py
+++ b/tubular/tests/test_salesforce_marketing_cloud.py
@@ -3,10 +3,9 @@ Tests for the Salesforce Marketing Cloud API functionality
 """
 
 import ddt
-import os
 import logging
-import unittest
-from unittest import mock
+import os
+from unittest import TestCase, mock
 
 import requests_mock
 
@@ -20,7 +19,7 @@ from tubular.salesforce_marketing_cloud_api import (
 
 @ddt.ddt
 @requests_mock.Mocker()
-class TestSalesforceMarketingCloud(unittest.TestCase):
+class TestSalesforceMarketingCloud(TestCase):
     """
     Class containing tests of all code interacting with Salesforce Marketing Cloud.
     """
@@ -31,8 +30,7 @@ class TestSalesforceMarketingCloud(unittest.TestCase):
         self.sfmc = SalesforceMarketingCloudApi(
             'test-client-id',
             'test-client-secret',
-            'test-subdomain',
-            'test-account-id'
+            'test-subdomain'
         )
         self.token_url = 'https://test-subdomain.auth.marketingcloudapis.com/v2/token'
         self.delete_url = 'https://test-subdomain.rest.marketingcloudapis.com/hub/v1/dataevents/key:Contacts_for_Delete/rowset'
@@ -85,13 +83,8 @@ class TestSalesforceMarketingCloud(unittest.TestCase):
     def test_delete_user_missing_user_id(self, req_mock):
         learner = {'user': {}}
         
-        with self.assertRaises(TypeError) as exc:
+        with self.assertRaises(KeyError):
             self.sfmc.delete_user(learner)
-        
-        self.assertEqual(
-            str(exc.exception),
-            'Expected a user ID for user to delete, but received None.'
-        )
 
     def test_delete_fatal_error(self, req_mock):
         self._mock_token_request(req_mock)
@@ -115,4 +108,25 @@ class TestSalesforceMarketingCloud(unittest.TestCase):
         with self.assertRaises(SalesforceMarketingCloudRecoverableException):
             self.sfmc.delete_user(self.learner)
 
+        self.assertGreaterEqual(len(req_mock.request_history), 2)
+
+    def test_token_fatal_error(self, req_mock):
+        self._mock_token_request(req_mock, status_code=401)
+
+        logger = logging.getLogger('tubular.salesforce_marketing_cloud_api')
+        with mock.patch.object(logger, 'error') as mock_error:
+            with self.assertRaises(SalesforceMarketingCloudException):
+                self.sfmc.delete_user(self.learner)
+
+        self.assertTrue(mock_error.called)
+        self.assertIn('SFMC token request failed', str(mock_error.call_args))
+
+    @ddt.data(429, 500)
+    def test_token_recoverable_error(self, status_code, req_mock):
+        self._mock_token_request(req_mock, status_code=status_code)
+
+        with self.assertRaises(SalesforceMarketingCloudRecoverableException):
+            self.sfmc.delete_user(self.learner)
+
+        # Should have retried with backoff
         self.assertGreaterEqual(len(req_mock.request_history), 2)


### PR DESCRIPTION
Description:

Tubular command to remove a retired user from SFMC

Private JIRA link:
 - https://2u-internal.atlassian.net/browse/BOMS-304