### PR TITLE
feat: Add support for exempt partners without POC in retirement reporting

### DIFF
--- a/tubular/scripts/helpers.py
+++ b/tubular/scripts/helpers.py
@@ -117,6 +117,16 @@ def _config_with_drive_or_exit(fail_func, config_fail_code, google_fail_code, co
         for org in config['org_partner_mapping']:
             partner = config['org_partner_mapping'][org]
             config['org_partner_mapping'][org] = [unicodedata.normalize('NFKC', text_type(partner)) for partner in config['org_partner_mapping'][org]]
+
+        # Set up partners that are exempt from POC requirements (optional configuration)
+        if 'partners_without_poc_required' not in config:
+            config['partners_without_poc_required'] = []
+        else:
+            # Normalize the exempt partner names the same way
+            config['partners_without_poc_required'] = [
+                unicodedata.normalize('NFKC', text_type(partner)) 
+                for partner in config['partners_without_poc_required']
+            ]
     except Exception as exc:  # pylint: disable=broad-except
         fail_func(config_fail_code, 'Failed to read config file {}'.format(config_file), exc)
 

--- a/tubular/scripts/helpers.py
+++ b/tubular/scripts/helpers.py
@@ -119,12 +119,12 @@ def _config_with_drive_or_exit(fail_func, config_fail_code, google_fail_code, co
             config['org_partner_mapping'][org] = [unicodedata.normalize('NFKC', text_type(partner)) for partner in config['org_partner_mapping'][org]]
 
         # Set up partners that are exempt from POC requirements.
-        if 'partners_without_poc_required' not in config:
+        if 'partners_without_poc_required' not in config or config['partners_without_poc_required'] is None:
             config['partners_without_poc_required'] = []
         else:
             # Normalize the exempt partner names the same way
             config['partners_without_poc_required'] = [
-                unicodedata.normalize('NFKC', text_type(partner)) 
+                unicodedata.normalize('NFKC', text_type(partner))
                 for partner in config['partners_without_poc_required']
             ]
     except Exception as exc:  # pylint: disable=broad-except

--- a/tubular/scripts/helpers.py
+++ b/tubular/scripts/helpers.py
@@ -119,13 +119,13 @@ def _config_with_drive_or_exit(fail_func, config_fail_code, google_fail_code, co
             config['org_partner_mapping'][org] = [unicodedata.normalize('NFKC', text_type(partner)) for partner in config['org_partner_mapping'][org]]
 
         # Set up partners that are exempt from POC requirements.
-        if 'partners_without_poc_required' not in config or config['partners_without_poc_required'] is None:
-            config['partners_without_poc_required'] = []
+        if 'exempted_partners' not in config or config['exempted_partners'] is None:
+            config['exempted_partners'] = []
         else:
             # Normalize the exempt partner names the same way
-            config['partners_without_poc_required'] = [
+            config['exempted_partners'] = [
                 unicodedata.normalize('NFKC', text_type(partner))
-                for partner in config['partners_without_poc_required']
+                for partner in config['exempted_partners']
             ]
     except Exception as exc:  # pylint: disable=broad-except
         fail_func(config_fail_code, 'Failed to read config file {}'.format(config_file), exc)

--- a/tubular/scripts/helpers.py
+++ b/tubular/scripts/helpers.py
@@ -118,7 +118,7 @@ def _config_with_drive_or_exit(fail_func, config_fail_code, google_fail_code, co
             partner = config['org_partner_mapping'][org]
             config['org_partner_mapping'][org] = [unicodedata.normalize('NFKC', text_type(partner)) for partner in config['org_partner_mapping'][org]]
 
-        # Set up partners that are exempt from POC requirements (optional configuration)
+        # Set up partners that are exempt from POC requirements.
         if 'partners_without_poc_required' not in config:
             config['partners_without_poc_required'] = []
         else:

--- a/tubular/scripts/retirement_partner_report.py
+++ b/tubular/scripts/retirement_partner_report.py
@@ -342,9 +342,10 @@ def _add_comments_to_files(config, file_ids):
     
     # Fail if any partners are missing POC and not exempt.
     if missing_poc_partners:
+        partner_word = 'partners' if len(missing_poc_partners) != 1 else 'partner'
         FAIL(ERR_MISSING_POC, 
-             'COMPLIANCE FAILURE: {} partner(s) missing POC: {}. Project Coordinators must be informed.'
-             .format(len(missing_poc_partners), ', '.join('"{}"'.format(p) for p in missing_poc_partners)))
+             'COMPLIANCE FAILURE: {} {} missing POC: {}. Project Coordinators must be informed.'
+             .format(len(missing_poc_partners), partner_word, ', '.join('"{}"'.format(p) for p in missing_poc_partners)))
 
     try:
         LOG('Adding notification comments to uploaded csv files.')

--- a/tubular/scripts/retirement_partner_report.py
+++ b/tubular/scripts/retirement_partner_report.py
@@ -318,11 +318,11 @@ def _add_comments_to_files(config, file_ids):
 
     file_ids_and_comments = []
     missing_poc_partners = []
-    
+
     for partner in file_ids:
         if not external_emails[partner]:
             # Check if this partner is exempt from POC requirements
-            if partner in config.get('partners_without_poc_required', []):
+            if partner in config.get('exempted_partners', []):
                 LOG(
                     'INFO: Partner "{}" is configured to not require a POC - skipping notification.'
                     .format(partner)
@@ -339,11 +339,11 @@ def _add_comments_to_files(config, file_ids):
             tag_string = ' '.join('+' + email for email in external_emails[partner])
             comment_content = NOTIFICATION_MESSAGE_TEMPLATE.format(tags=tag_string)
             file_ids_and_comments.append((file_ids[partner], comment_content))
-    
+
     # Fail if any partners are missing POC and not exempt.
     if missing_poc_partners:
         partner_word = 'partners' if len(missing_poc_partners) != 1 else 'partner'
-        FAIL(ERR_MISSING_POC, 
+        FAIL(ERR_MISSING_POC,
              'COMPLIANCE FAILURE: {} {} missing POC: {}. Project Coordinators must be informed.'
              .format(len(missing_poc_partners), partner_word, ', '.join('"{}"'.format(p) for p in missing_poc_partners)))
 

--- a/tubular/scripts/retirement_partner_report.py
+++ b/tubular/scripts/retirement_partner_report.py
@@ -332,8 +332,7 @@ def _add_comments_to_files(config, file_ids):
                 missing_poc_partners.append(partner)
                 LOG(
                     'ERROR: Could not find a Point of Contact (POC) for partner: "{}". '
-                    'This is a COMPLIANCE ISSUE - partners must have a POC to be notified '
-                    'when learners are retired. Double check the partner folder permissions in Google Drive.'
+                    'Double check the partner folder permissions in Google Drive.'
                     .format(partner)
                 )
         else:
@@ -341,12 +340,10 @@ def _add_comments_to_files(config, file_ids):
             comment_content = NOTIFICATION_MESSAGE_TEMPLATE.format(tags=tag_string)
             file_ids_and_comments.append((file_ids[partner], comment_content))
     
-    # Fail if any partners are missing POC (and not exempt)
+    # Fail if any partners are missing POC and not exempt.
     if missing_poc_partners:
         FAIL(ERR_MISSING_POC, 
-             'COMPLIANCE FAILURE: The following {} partner(s) do not have a Point of Contact configured: {}. '
-             'Partners must have a POC to fulfill compliance requirements for learner retirement notifications. '
-             'Project Coordinators must be informed to resolve this immediately.'
+             'COMPLIANCE FAILURE: {} partner(s) missing POC: {}. Project Coordinators must be informed.'
              .format(len(missing_poc_partners), ', '.join('"{}"'.format(p) for p in missing_poc_partners)))
 
     try:

--- a/tubular/tests/retirement_helpers.py
+++ b/tubular/tests/retirement_helpers.py
@@ -54,7 +54,7 @@ def flatten_partner_list(partner_list):
     return [partner for sublist in partner_list for partner in sublist]
 
 
-def fake_config_file(f, orgs=None, fetch_ecom_segment_id=False):
+def fake_config_file(f, orgs=None, fetch_ecom_segment_id=False, exempted_partners=None):
     """
     Create a config file for a single test. Combined with CliRunner.isolated_filesystem() to
     ensure the file lifetime is limited to the test. See _call_script for usage.
@@ -88,6 +88,9 @@ def fake_config_file(f, orgs=None, fetch_ecom_segment_id=False):
 
     if fetch_ecom_segment_id:
         config['fetch_ecommerce_segment_id'] = True
+
+    if exempted_partners:
+        config['partners_without_poc_required'] = exempted_partners
 
     yaml.safe_dump(config, f)
 

--- a/tubular/tests/retirement_helpers.py
+++ b/tubular/tests/retirement_helpers.py
@@ -90,7 +90,7 @@ def fake_config_file(f, orgs=None, fetch_ecom_segment_id=False, exempted_partner
         config['fetch_ecommerce_segment_id'] = True
 
     if exempted_partners:
-        config['partners_without_poc_required'] = exempted_partners
+        config['exempted_partners'] = exempted_partners
 
     yaml.safe_dump(config, f)
 


### PR DESCRIPTION
### Description:
Partner retirement reports logged warnings for missing Points of Contact (POCs) but continued processing, creating compliance violations. Partners without POCs cannot be properly notified during learner retirement.

### Solution:

- Convert POC warnings to job failures with exit code `ERR_MISSING_POC = -13`
- Add exempted_partners config for exemptions (e.g., "Expired" partners)
- Include `COMPLIANCE FAILURE` messaging for Project Coordinator alerts

### Implementation:

- `retirement_partner_report.py`: Added compliance failure logic
- `helpers.py`: Added exemption configuration support
- Test files: Comprehensive coverage for all scenarios

### Private JIRA Link:
[BOMS-196](https://2u-internal.atlassian.net/browse/BOMS-296)
