### PR TITLE
fix!: redacting user retirement data in lms

### DIFF
--- a/tubular/edx_api.py
+++ b/tubular/edx_api.py
@@ -361,13 +361,13 @@ class LmsApi(BaseApiClient):
         return self._request('POST', api_url)
 
     @_retry_lms_api()
-    def bulk_cleanup_retirements(self, usernames, jenkins_run_id=None):
+    def bulk_cleanup_retirements(self, usernames, run_id=None):
         """
         Deletes the retirements for all given usernames
         """
         data = {'usernames': usernames}
-        if jenkins_run_id:
-            data['jenkins_run_id'] = jenkins_run_id
+        if run_id:
+            data['run_id'] = run_id
         api_url = self.get_api_url('api/user/v1/accounts/retirement_cleanup')
         return self._request('POST', api_url, json=data)
 

--- a/tubular/edx_api.py
+++ b/tubular/edx_api.py
@@ -361,11 +361,13 @@ class LmsApi(BaseApiClient):
         return self._request('POST', api_url)
 
     @_retry_lms_api()
-    def bulk_cleanup_retirements(self, usernames):
+    def bulk_cleanup_retirements(self, usernames, jenkins_run_id=None):
         """
         Deletes the retirements for all given usernames
         """
         data = {'usernames': usernames}
+        if jenkins_run_id:
+            data['jenkins_run_id'] = jenkins_run_id
         api_url = self.get_api_url('api/user/v1/accounts/retirement_cleanup')
         return self._request('POST', api_url, json=data)
 

--- a/tubular/edx_api.py
+++ b/tubular/edx_api.py
@@ -361,13 +361,13 @@ class LmsApi(BaseApiClient):
         return self._request('POST', api_url)
 
     @_retry_lms_api()
-    def bulk_cleanup_retirements(self, usernames, run_id=None):
+    def bulk_cleanup_retirements(self, usernames, redaction_id=None):
         """
         Deletes the retirements for all given usernames
         """
         data = {'usernames': usernames}
-        if run_id:
-            data['run_id'] = run_id
+        if redaction_id:
+            data['redaction_id'] = redaction_id
         api_url = self.get_api_url('api/user/v1/accounts/retirement_cleanup')
         return self._request('POST', api_url, json=data)
 

--- a/tubular/edx_api.py
+++ b/tubular/edx_api.py
@@ -361,24 +361,14 @@ class LmsApi(BaseApiClient):
         return self._request('POST', api_url)
 
     @_retry_lms_api()
-    def bulk_cleanup_retirements(
-        self,
-        usernames,
-        redacted_username=None,
-        redacted_email=None,
-        redacted_name=None,
-    ):
+    def bulk_cleanup_retirements(self, usernames, redacted_value=None):
         """
-        Deletes the retirements for all given usernames.
-        Optionally pass caller-defined redacted values for username/email/name.
+        Redacts the retirements for all given usernames.
+        Optionally pass caller-defined redacted value for PII fields.
         """
         data = {'usernames': usernames}
-        if redacted_username is not None:
-            data['redacted_username'] = redacted_username
-        if redacted_email is not None:
-            data['redacted_email'] = redacted_email
-        if redacted_name is not None:
-            data['redacted_name'] = redacted_name
+        if redacted_value is not None:
+            data['redacted_value'] = redacted_value
         api_url = self.get_api_url('api/user/v1/accounts/retirement_cleanup')
         return self._request('POST', api_url, json=data)
 

--- a/tubular/edx_api.py
+++ b/tubular/edx_api.py
@@ -361,13 +361,24 @@ class LmsApi(BaseApiClient):
         return self._request('POST', api_url)
 
     @_retry_lms_api()
-    def bulk_cleanup_retirements(self, usernames, redaction_id=None):
+    def bulk_cleanup_retirements(
+        self,
+        usernames,
+        redacted_username=None,
+        redacted_email=None,
+        redacted_name=None,
+    ):
         """
-        Deletes the retirements for all given usernames
+        Deletes the retirements for all given usernames.
+        Optionally pass caller-defined redacted values for username/email/name.
         """
         data = {'usernames': usernames}
-        if redaction_id:
-            data['redaction_id'] = redaction_id
+        if redacted_username is not None:
+            data['redacted_username'] = redacted_username
+        if redacted_email is not None:
+            data['redacted_email'] = redacted_email
+        if redacted_name is not None:
+            data['redacted_name'] = redacted_name
         api_url = self.get_api_url('api/user/v1/accounts/retirement_cleanup')
         return self._request('POST', api_url, json=data)
 

--- a/tubular/edx_api.py
+++ b/tubular/edx_api.py
@@ -364,7 +364,6 @@ class LmsApi(BaseApiClient):
     def bulk_cleanup_retirements(self, usernames, redacted_value=None):
         """
         Redacts the retirements for all given usernames.
-        Optionally pass caller-defined redacted value for PII fields.
         """
         data = {'usernames': usernames}
         if redacted_value is not None:

--- a/tubular/edx_api.py
+++ b/tubular/edx_api.py
@@ -361,13 +361,18 @@ class LmsApi(BaseApiClient):
         return self._request('POST', api_url)
 
     @_retry_lms_api()
-    def bulk_cleanup_retirements(self, usernames, redacted_value=None):
+    def bulk_cleanup_retirements(self, usernames, redacted_username=None, redacted_email=None, redacted_name=None):
         """
         Redacts the retirements for all given usernames.
+        Optionally pass caller-defined redacted values for each PII field.
         """
         data = {'usernames': usernames}
-        if redacted_value is not None:
-            data['redacted_value'] = redacted_value
+        if redacted_username is not None:
+            data['redacted_username'] = redacted_username
+        if redacted_email is not None:
+            data['redacted_email'] = redacted_email
+        if redacted_name is not None:
+            data['redacted_name'] = redacted_name
         api_url = self.get_api_url('api/user/v1/accounts/retirement_cleanup')
         return self._request('POST', api_url, json=data)
 

--- a/tubular/scripts/retirement_archive_and_cleanup.py
+++ b/tubular/scripts/retirement_archive_and_cleanup.py
@@ -201,14 +201,14 @@ def _archive_retirements_or_exit(config, learners, dry_run=False):
         FAIL_EXCEPTION(ERR_ARCHIVING, 'Unexpected error occurred archiving retirements!', exc)
 
 
-def _cleanup_retirements_or_exit(config, learners, run_id=None):
+def _cleanup_retirements_or_exit(config, learners, redaction_id=None):
     """
     Bulk deletes the retirements for this run
     """
     LOG('Cleaning up retirements for {} learners'.format(len(learners)))
     try:
         usernames = [l['original_username'] for l in learners]
-        config['LMS'].bulk_cleanup_retirements(usernames, run_id)
+        config['LMS'].bulk_cleanup_retirements(usernames, redaction_id)
     except Exception as exc:  # pylint: disable=broad-except
         FAIL_EXCEPTION(ERR_DELETING, 'Unexpected error occurred deleting retirements!', exc)
 
@@ -264,11 +264,11 @@ def _get_utc_now():
     type=int
 )
 @click.option(
-    '--run_id',
+    '--redaction_id',
     help='Identifier for this cleanup run (e.g. build/job number)',
     type=str
 )
-def archive_and_cleanup(config_file, cool_off_days, dry_run, start_date, end_date, batch_size, run_id):
+def archive_and_cleanup(config_file, cool_off_days, dry_run, start_date, end_date, batch_size, redaction_id):
     """
     Cleans up UserRetirementStatus rows in LMS by:
     1- Getting all rows currently in COMPLETE that were created --cool_off_days ago or more,
@@ -324,7 +324,7 @@ def archive_and_cleanup(config_file, cool_off_days, dry_run, start_date, end_dat
                 if dry_run:
                     LOG('This is a dry-run. Exiting before any retirements are cleaned up')
                 else:
-                    _cleanup_retirements_or_exit(config, batch, run_id)
+                    _cleanup_retirements_or_exit(config, batch, redaction_id)
                     LOG('Archive and cleanup complete for batch #{}'.format(str(index + 1)))
                     time.sleep(DELAY)
         else:

--- a/tubular/scripts/retirement_archive_and_cleanup.py
+++ b/tubular/scripts/retirement_archive_and_cleanup.py
@@ -201,14 +201,25 @@ def _archive_retirements_or_exit(config, learners, dry_run=False):
         FAIL_EXCEPTION(ERR_ARCHIVING, 'Unexpected error occurred archiving retirements!', exc)
 
 
-def _cleanup_retirements_or_exit(config, learners, redaction_id=None):
+def _cleanup_retirements_or_exit(
+    config,
+    learners,
+    redacted_username='redacted',
+    redacted_email='redacted',
+    redacted_name='redacted',
+):
     """
     Bulk deletes the retirements for this run
     """
     LOG('Cleaning up retirements for {} learners'.format(len(learners)))
     try:
         usernames = [l['original_username'] for l in learners]
-        config['LMS'].bulk_cleanup_retirements(usernames, redaction_id)
+        config['LMS'].bulk_cleanup_retirements(
+            usernames,
+            redacted_username,
+            redacted_email,
+            redacted_name,
+        )
     except Exception as exc:  # pylint: disable=broad-except
         FAIL_EXCEPTION(ERR_DELETING, 'Unexpected error occurred deleting retirements!', exc)
 
@@ -264,11 +275,34 @@ def _get_utc_now():
     type=int
 )
 @click.option(
-    '--redaction_id',
-    help='Identifier for this cleanup run (e.g. build/job number)',
-    type=str
+    '--redacted_username',
+    help='Value to write to LMS original_username field',
+    type=str,
+    default='redacted'
 )
-def archive_and_cleanup(config_file, cool_off_days, dry_run, start_date, end_date, batch_size, redaction_id):
+@click.option(
+    '--redacted_email',
+    help='Value to write to LMS original_email field',
+    type=str,
+    default='redacted'
+)
+@click.option(
+    '--redacted_name',
+    help='Value to write to LMS original_name field',
+    type=str,
+    default='redacted'
+)
+def archive_and_cleanup(
+    config_file,
+    cool_off_days,
+    dry_run,
+    start_date,
+    end_date,
+    batch_size,
+    redacted_username,
+    redacted_email,
+    redacted_name,
+):
     """
     Cleans up UserRetirementStatus rows in LMS by:
     1- Getting all rows currently in COMPLETE that were created --cool_off_days ago or more,
@@ -324,7 +358,13 @@ def archive_and_cleanup(config_file, cool_off_days, dry_run, start_date, end_dat
                 if dry_run:
                     LOG('This is a dry-run. Exiting before any retirements are cleaned up')
                 else:
-                    _cleanup_retirements_or_exit(config, batch, redaction_id)
+                    _cleanup_retirements_or_exit(
+                        config,
+                        batch,
+                        redacted_username,
+                        redacted_email,
+                        redacted_name,
+                    )
                     LOG('Archive and cleanup complete for batch #{}'.format(str(index + 1)))
                     time.sleep(DELAY)
         else:

--- a/tubular/scripts/retirement_archive_and_cleanup.py
+++ b/tubular/scripts/retirement_archive_and_cleanup.py
@@ -201,14 +201,14 @@ def _archive_retirements_or_exit(config, learners, dry_run=False):
         FAIL_EXCEPTION(ERR_ARCHIVING, 'Unexpected error occurred archiving retirements!', exc)
 
 
-def _cleanup_retirements_or_exit(config, learners, jenkins_run_id=None):
+def _cleanup_retirements_or_exit(config, learners, run_id=None):
     """
     Bulk deletes the retirements for this run
     """
     LOG('Cleaning up retirements for {} learners'.format(len(learners)))
     try:
         usernames = [l['original_username'] for l in learners]
-        config['LMS'].bulk_cleanup_retirements(usernames, jenkins_run_id)
+        config['LMS'].bulk_cleanup_retirements(usernames, run_id)
     except Exception as exc:  # pylint: disable=broad-except
         FAIL_EXCEPTION(ERR_DELETING, 'Unexpected error occurred deleting retirements!', exc)
 
@@ -264,11 +264,11 @@ def _get_utc_now():
     type=int
 )
 @click.option(
-    '--jenkins_run_id',
-    help='Jenkins BUILD_NUMBER for tracking the job run that performs cleanup',
+    '--run_id',
+    help='Identifier for this cleanup run (e.g. build/job number)',
     type=str
 )
-def archive_and_cleanup(config_file, cool_off_days, dry_run, start_date, end_date, batch_size, jenkins_run_id):
+def archive_and_cleanup(config_file, cool_off_days, dry_run, start_date, end_date, batch_size, run_id):
     """
     Cleans up UserRetirementStatus rows in LMS by:
     1- Getting all rows currently in COMPLETE that were created --cool_off_days ago or more,
@@ -324,7 +324,7 @@ def archive_and_cleanup(config_file, cool_off_days, dry_run, start_date, end_dat
                 if dry_run:
                     LOG('This is a dry-run. Exiting before any retirements are cleaned up')
                 else:
-                    _cleanup_retirements_or_exit(config, batch, jenkins_run_id)
+                    _cleanup_retirements_or_exit(config, batch, run_id)
                     LOG('Archive and cleanup complete for batch #{}'.format(str(index + 1)))
                     time.sleep(DELAY)
         else:

--- a/tubular/scripts/retirement_archive_and_cleanup.py
+++ b/tubular/scripts/retirement_archive_and_cleanup.py
@@ -68,7 +68,7 @@ def _fetch_learners_to_archive_or_exit(config, start_date, end_date, initial_sta
 def _batch_learners(learners=None, batch_size=None):
     """
     To avoid potentially overwheling the LMS with a large number of user retirements to
-    delete, create a list of smaller batches of users to iterate over. This has the
+    redact, create a list of smaller batches of users to iterate over. This has the
     added benefit of reducing the amount of user retirement archive requests that can
     get into a bad state should this script experience an error.
 
@@ -226,7 +226,7 @@ def _get_utc_now():
 )
 @click.option(
     '--cool_off_days',
-    help='Number of days a retirement should exist before being archived and deleted.',
+    help='Number of days a retirement should exist before being archived and redacted.',
     type=int,
     default=37  # 7 days before retirement, 30 after
 )

--- a/tubular/scripts/retirement_archive_and_cleanup.py
+++ b/tubular/scripts/retirement_archive_and_cleanup.py
@@ -67,7 +67,7 @@ def _fetch_learners_to_archive_or_exit(config, start_date, end_date, initial_sta
 
 def _batch_learners(learners=None, batch_size=None):
     """
-    To avoid potentially overwheling the LMS with a large number of user retirements to
+    To avoid potentially overwhelming the LMS with a large number of user retirements to
     redact, create a list of smaller batches of users to iterate over. This has the
     added benefit of reducing the amount of user retirement archive requests that can
     get into a bad state should this script experience an error.
@@ -283,7 +283,7 @@ def archive_and_cleanup(
     1- Getting all rows currently in COMPLETE that were created --cool_off_days ago or more,
         unless a specific timeframe is specified
     2- Archiving them to S3 in an Athena-queryable format
-    3- Deleting them from LMS (by username)
+    3- Redacting them from LMS (by username)
     """
     try:
         LOG('Starting bulk update script: Config: {}'.format(config_file))

--- a/tubular/scripts/retirement_archive_and_cleanup.py
+++ b/tubular/scripts/retirement_archive_and_cleanup.py
@@ -201,14 +201,14 @@ def _archive_retirements_or_exit(config, learners, dry_run=False):
         FAIL_EXCEPTION(ERR_ARCHIVING, 'Unexpected error occurred archiving retirements!', exc)
 
 
-def _cleanup_retirements_or_exit(config, learners, redacted_value='redacted'):
+def _cleanup_retirements_or_exit(config, learners, redacted_username='redacted', redacted_email='redacted', redacted_name='redacted'):
     """
     Bulk redacts the retirements for this run
     """
     LOG('Cleaning up retirements for {} learners'.format(len(learners)))
     try:
         usernames = [l['original_username'] for l in learners]
-        config['LMS'].bulk_cleanup_retirements(usernames, redacted_value)
+        config['LMS'].bulk_cleanup_retirements(usernames, redacted_username, redacted_email, redacted_name)
     except Exception as exc:  # pylint: disable=broad-except
         FAIL_EXCEPTION(ERR_DELETING, 'Unexpected error occurred redacting retirements!', exc)
 
@@ -264,8 +264,20 @@ def _get_utc_now():
     type=int
 )
 @click.option(
-    '--redacted_value',
-    help='Value to redact PII fields (username, email, name)',
+    '--redacted_username',
+    help='Value to redact username field with',
+    type=str,
+    default='redacted'
+)
+@click.option(
+    '--redacted_email',
+    help='Value to redact email field with',
+    type=str,
+    default='redacted'
+)
+@click.option(
+    '--redacted_name',
+    help='Value to redact name field with',
     type=str,
     default='redacted'
 )
@@ -276,7 +288,9 @@ def archive_and_cleanup(
     start_date,
     end_date,
     batch_size,
-    redacted_value,
+    redacted_username,
+    redacted_email,
+    redacted_name,
 ):
     """
     Cleans up UserRetirementStatus rows in LMS by:
@@ -333,7 +347,7 @@ def archive_and_cleanup(
                 if dry_run:
                     LOG('This is a dry-run. Exiting before any retirements are cleaned up')
                 else:
-                    _cleanup_retirements_or_exit(config, batch, redacted_value)
+                    _cleanup_retirements_or_exit(config, batch, redacted_username, redacted_email, redacted_name)
                     LOG('Archive and cleanup complete for batch #{}'.format(str(index + 1)))
                     time.sleep(DELAY)
         else:

--- a/tubular/tests/test_retirement_archive_and_cleanup.py
+++ b/tubular/tests/test_retirement_archive_and_cleanup.py
@@ -215,7 +215,7 @@ def test_bad_fetch(*_):
 def test_bad_lms_deletion(*_):
     result = _call_script()
     assert result.exit_code == ERR_DELETING
-    assert 'Unexpected error occurred deleting retirements!' in result.output
+    assert 'Unexpected error occurred redacting retirements!' in result.output
 
 
 @patch('tubular.edx_api.BaseApiClient.get_access_token', return_value=('THIS_IS_A_JWT', None))

--- a/tubular/tests/test_retirement_archive_and_cleanup.py
+++ b/tubular/tests/test_retirement_archive_and_cleanup.py
@@ -102,7 +102,7 @@ def test_successful(*args, **kwargs):
     assert mock_get_access_token.call_count == 1
     mock_get_learners.assert_called_once()
     mock_bulk_cleanup_retirements.assert_called_once_with(
-        ['test1', 'test2', 'test3'], 'redacted')
+        ['test1', 'test2', 'test3'], 'redacted', 'redacted', 'redacted')
 
     assert result.exit_code == 0
     assert 'Archive and cleanup complete' in result.output
@@ -132,8 +132,8 @@ def test_successful_with_batching(*args, **kwargs):
     assert mock_get_access_token.call_count == 1
     mock_get_learners.assert_called_once()
     get_learner_calls = [
-        call(['test1', 'test2'], 'redacted'),
-        call(['test3'], 'redacted')
+        call(['test1', 'test2'], 'redacted', 'redacted', 'redacted'),
+        call(['test3'], 'redacted', 'redacted', 'redacted')
     ]
     mock_bulk_cleanup_retirements.assert_has_calls(get_learner_calls)
 

--- a/tubular/tests/test_retirement_archive_and_cleanup.py
+++ b/tubular/tests/test_retirement_archive_and_cleanup.py
@@ -102,7 +102,7 @@ def test_successful(*args, **kwargs):
     assert mock_get_access_token.call_count == 1
     mock_get_learners.assert_called_once()
     mock_bulk_cleanup_retirements.assert_called_once_with(
-        ['test1', 'test2', 'test3'], None)
+        ['test1', 'test2', 'test3'], 'redacted', 'redacted', 'redacted')
 
     assert result.exit_code == 0
     assert 'Archive and cleanup complete' in result.output
@@ -131,7 +131,10 @@ def test_successful_with_batching(*args, **kwargs):
     # Called once to get the LMS token
     assert mock_get_access_token.call_count == 1
     mock_get_learners.assert_called_once()
-    get_learner_calls = [call(['test1', 'test2'], None), call(['test3'], None)]
+    get_learner_calls = [
+        call(['test1', 'test2'], 'redacted', 'redacted', 'redacted'),
+        call(['test3'], 'redacted', 'redacted', 'redacted')
+    ]
     mock_bulk_cleanup_retirements.assert_has_calls(get_learner_calls)
 
     assert result.exit_code == 0

--- a/tubular/tests/test_retirement_archive_and_cleanup.py
+++ b/tubular/tests/test_retirement_archive_and_cleanup.py
@@ -102,7 +102,7 @@ def test_successful(*args, **kwargs):
     assert mock_get_access_token.call_count == 1
     mock_get_learners.assert_called_once()
     mock_bulk_cleanup_retirements.assert_called_once_with(
-        ['test1', 'test2', 'test3'], 'redacted', 'redacted', 'redacted')
+        ['test1', 'test2', 'test3'], 'redacted')
 
     assert result.exit_code == 0
     assert 'Archive and cleanup complete' in result.output
@@ -132,8 +132,8 @@ def test_successful_with_batching(*args, **kwargs):
     assert mock_get_access_token.call_count == 1
     mock_get_learners.assert_called_once()
     get_learner_calls = [
-        call(['test1', 'test2'], 'redacted', 'redacted', 'redacted'),
-        call(['test3'], 'redacted', 'redacted', 'redacted')
+        call(['test1', 'test2'], 'redacted'),
+        call(['test3'], 'redacted')
     ]
     mock_bulk_cleanup_retirements.assert_has_calls(get_learner_calls)
 

--- a/tubular/tests/test_retirement_archive_and_cleanup.py
+++ b/tubular/tests/test_retirement_archive_and_cleanup.py
@@ -102,7 +102,7 @@ def test_successful(*args, **kwargs):
     assert mock_get_access_token.call_count == 1
     mock_get_learners.assert_called_once()
     mock_bulk_cleanup_retirements.assert_called_once_with(
-        ['test1', 'test2', 'test3'])
+        ['test1', 'test2', 'test3'], None)
 
     assert result.exit_code == 0
     assert 'Archive and cleanup complete' in result.output
@@ -131,7 +131,7 @@ def test_successful_with_batching(*args, **kwargs):
     # Called once to get the LMS token
     assert mock_get_access_token.call_count == 1
     mock_get_learners.assert_called_once()
-    get_learner_calls = [call(['test1', 'test2']), call(['test3'])]
+    get_learner_calls = [call(['test1', 'test2'], None), call(['test3'], None)]
     mock_bulk_cleanup_retirements.assert_has_calls(get_learner_calls)
 
     assert result.exit_code == 0


### PR DESCRIPTION
# Description
This PR adds a new option to the retirement cleanup script that lets you pass a custom placeholder value to replace user information. It then sends this value through to the LMS system so both systems can work together to redact user data.

# Private Link Ticket
https://2u-internal.atlassian.net/browse/BOMS-293