### PR TITLE
feat: enhanced first notify for poc users and then fail for non-poc users

### DIFF
--- a/tubular/scripts/retirement_partner_report.py
+++ b/tubular/scripts/retirement_partner_report.py
@@ -340,19 +340,20 @@ def _add_comments_to_files(config, file_ids):
             comment_content = NOTIFICATION_MESSAGE_TEMPLATE.format(tags=tag_string)
             file_ids_and_comments.append((file_ids[partner], comment_content))
 
+    if file_ids_and_comments:
+        try:
+            LOG('Adding notification comments to uploaded csv files.')
+            drive.create_comments_for_files(file_ids_and_comments)
+        except Exception as exc:  # pylint: disable=broad-except
+            # do not fail the script here, since comment errors are non-critical
+            LOG('WARNING: there was an error adding Google Drive comments to the csv files: {}'.format(exc))
+
     # Fail if any partners are missing POC and not exempt.
     if missing_poc_partners:
         partner_word = 'partners' if len(missing_poc_partners) != 1 else 'partner'
         FAIL(ERR_MISSING_POC,
              'COMPLIANCE FAILURE: {} {} missing POC: {}. Project Coordinators must be informed.'
              .format(len(missing_poc_partners), partner_word, ', '.join('"{}"'.format(p) for p in missing_poc_partners)))
-
-    try:
-        LOG('Adding notification comments to uploaded csv files.')
-        drive.create_comments_for_files(file_ids_and_comments)
-    except Exception as exc:  # pylint: disable=broad-except
-        # do not fail the script here, since comment errors are non-critical
-        LOG('WARNING: there was an error adding Google Drive comments to the csv files: {}'.format(exc))
 
 
 @click.command("generate_report")

--- a/tubular/tests/test_retirement_partner_report.py
+++ b/tubular/tests/test_retirement_partner_report.py
@@ -280,6 +280,7 @@ def test_successful_report(*args, **kwargs):
 @patch('tubular.google_api.DriveApi.create_file_in_folder')
 @patch('tubular.google_api.DriveApi.walk_files')
 @patch('tubular.google_api.DriveApi.list_permissions_for_files')
+@patch('tubular.google_api.DriveApi.create_comments_for_files')
 @patch('tubular.edx_api.BaseApiClient.get_access_token')
 @patch.multiple(
     'tubular.edx_api.LmsApi',
@@ -288,17 +289,19 @@ def test_successful_report(*args, **kwargs):
 )
 def test_missing_poc_failure(*args, **kwargs):
     """
-    Test that missing POC causes compliance failure
+    Test that missing POC causes compliance failure, but partners with POCs are still notified
     """
     mock_get_access_token = args[0]
-    mock_list_permissions = args[1]
-    mock_walk_files = args[2]
-    mock_create_files = args[3]
-    mock_driveapi = args[4]
+    mock_create_comments = args[1]
+    mock_list_permissions = args[2]
+    mock_walk_files = args[3]
+    mock_create_files = args[4]
+    mock_driveapi = args[5]
     mock_retirement_report = kwargs['retirement_partner_report']
     mock_retirement_cleanup = kwargs['retirement_partner_cleanup']
 
     mock_get_access_token.return_value = ('THIS_IS_A_JWT', None)
+    mock_create_comments.return_value = None
     fake_partners = list(itervalues(FAKE_ORGS))
 
     # Some partners have POCs, but the last one does not
@@ -331,6 +334,14 @@ def test_missing_poc_failure(*args, **kwargs):
     assert 'Point of Contact' in result.output  # From CRITICAL log message
     assert 'missing POC' in result.output  # From FAIL compliance message
     assert 'Project Coordinators must be informed' in result.output
+
+    # NEW: Verify that partners WITH POCs were still notified before the job failed
+    assert mock_create_comments.call_count == 1
+    create_comments_file_ids, create_comments_messages = zip(*mock_create_comments.call_args[0][0])
+    # Should have comments for the first 2 orgs (that have POCs), but not the 3rd org (no POC)
+    expected_partners_with_poc = flatten_partner_list(fake_partners[:2])
+    assert len(create_comments_file_ids) == len(expected_partners_with_poc)
+    assert all('+some.contact@example.com' in msg for msg in create_comments_messages)
 
     # Ensure cleanup was NOT called since the job failed
     mock_retirement_cleanup.assert_not_called()

--- a/tubular/tests/test_retirement_partner_report.py
+++ b/tubular/tests/test_retirement_partner_report.py
@@ -335,10 +335,8 @@ def test_missing_poc_failure(*args, **kwargs):
     assert 'missing POC' in result.output  # From FAIL compliance message
     assert 'Project Coordinators must be informed' in result.output
 
-    # NEW: Verify that partners WITH POCs were still notified before the job failed
     assert mock_create_comments.call_count == 1
     create_comments_file_ids, create_comments_messages = zip(*mock_create_comments.call_args[0][0])
-    # Should have comments for the first 2 orgs (that have POCs), but not the 3rd org (no POC)
     expected_partners_with_poc = flatten_partner_list(fake_partners[:2])
     assert len(create_comments_file_ids) == len(expected_partners_with_poc)
     assert all('+some.contact@example.com' in msg for msg in create_comments_messages)


### PR DESCRIPTION
### Description:
When any partner was missing a POC, the job would fail immediately without notifying ANY partners - even those with valid POCs. This meant compliant partners were blocked by non-compliant partners' issues.

### Solution:
Reordered the notification flow to notify compliant partners first, then fail:

- Partners with valid POCs receive their retirement reports immediately
- Only after successful notification does the job fail for missing POCs
- Maintains compliance alerting while preventing compliant partners from being blocked
- Technical team still gets alerted via Jenkins when job fails

### Related PR:

- https://github.com/edx/tubular/pull/49

### Private JIRA Link:
[BOMS-296](https://2u-internal.atlassian.net/browse/BOMS-296)