### PR TITLE
feat: Enhance GitHub checks validation logic and add deployment gate options

### DIFF
--- a/tubular/github_api.py
+++ b/tubular/github_api.py
@@ -632,7 +632,8 @@ class GitHubAPI:
             # result = (success_bool, statuses_dict, aggregate_status)
             
             # If no checks were found, return success to avoid waiting forever
-            if result[2] == 'no_checks':
+            # Check for both 'no_checks' (explicitly set) and '' (empty string for backward compatibility)
+            if result[2] in ('no_checks', ''):
                 LOG.info("No checks found for commit {}. Polling will return success.".format(sha[:7]))
                 return ("success", None)
             

--- a/tubular/github_api.py
+++ b/tubular/github_api.py
@@ -432,7 +432,7 @@ class GitHubAPI:
                 suite['url']
             )
             for suite in check_suites['check_suites']
-            if self.all_checks
+            if self.all_checks or suite['app']['name'] in required_checks
         })
 
         # get more results from commit check runs

--- a/tubular/github_api.py
+++ b/tubular/github_api.py
@@ -422,22 +422,18 @@ class GitHubAPI:
         check_suites = self.get_commit_check_suites(commit)
         results.update({
             suite['app']['name']: (
-                # Use status field when conclusion is None, default to 'pending' if both are None
-                (suite.get('conclusion') if suite.get('conclusion') is not None 
-                 else (suite.get('status') if suite.get('status') is not None else 'pending')).lower(),
+                suite.get('conclusion').lower() if suite.get('conclusion') is not None else 'pending',
                 suite['url']
             )
             for suite in check_suites['check_suites']
-            if self.all_checks or suite['app']['name'] in required_checks
+            if self.all_checks
         })
 
         # get more results from commit check runs
         check_runs = self.get_commit_check_runs(commit)
         results.update({
             suite['name']: (
-                # Use status field when conclusion is None, default to 'pending' if both are None
-                (suite.get('conclusion') if suite.get('conclusion') is not None 
-                 else (suite.get('status') if suite.get('status') is not None else 'pending')).lower(),
+                suite.get('conclusion').lower() if suite.get('conclusion') is not None else 'pending',
                 suite['url']
             )
             for suite in check_runs['check_runs']
@@ -487,9 +483,9 @@ class GitHubAPI:
         """
         Aggregate validation results. Returns 'success' if all validations
         are 'success' or 'neutral', 'pending' if any validations are 'pending',
-        'in_progress', 'queued', 'waiting', or 'requested', or 'failure' otherwise.
+        or 'failure' otherwise.
         """
-        if any(state in ('pending', 'in_progress', 'queued', 'waiting', 'requested', None) for (state, url) in results.values()):
+        if any(state in ('pending', None) for (state, url) in results.values()):
             return 'pending'
         if all(state in ('success', 'neutral', 'skipped') for (state, url) in results.values()):
             return 'success'

--- a/tubular/github_api.py
+++ b/tubular/github_api.py
@@ -423,7 +423,8 @@ class GitHubAPI:
         results.update({
             suite['app']['name']: (
                 # Use status field when conclusion is None, default to 'pending' if both are None
-                (suite.get('conclusion') or suite.get('status') or 'pending').lower(),
+                (suite.get('conclusion') if suite.get('conclusion') is not None 
+                 else (suite.get('status') if suite.get('status') is not None else 'pending')).lower(),
                 suite['url']
             )
             for suite in check_suites['check_suites']
@@ -435,7 +436,8 @@ class GitHubAPI:
         results.update({
             suite['name']: (
                 # Use status field when conclusion is None, default to 'pending' if both are None
-                (suite.get('conclusion') or suite.get('status') or 'pending').lower(),
+                (suite.get('conclusion') if suite.get('conclusion') is not None 
+                 else (suite.get('status') if suite.get('status') is not None else 'pending')).lower(),
                 suite['url']
             )
             for suite in check_runs['check_runs']

--- a/tubular/github_api.py
+++ b/tubular/github_api.py
@@ -410,6 +410,12 @@ class GitHubAPI:
         required_checks = self.get_branch_protection_rules()
 
         results = {}
+
+        # The Commit Status API (combined_status) is the legacy API and only includes
+        # statuses created via the status API. Modern GitHub Actions workflows and their
+        # individual jobs appear as Check Runs, not statuses. Since branch protection
+        # rules can require specific Check Run names (like "Unit tests successful"),
+        # we must use the Check Runs API - we cannot rely solely on the Status API.
         combined_status = self.get_commit_combined_statuses(commit)
         results.update({
             status.context: (
@@ -439,6 +445,13 @@ class GitHubAPI:
             for suite in check_runs['check_runs']
             if self.all_checks or suite['name'] in required_checks
         })
+
+        # If a required check is missing from the results, add it as pending to block deployment.
+        # This ensures we wait for ALL required checks to be created and pass.
+        if not self.all_checks and required_checks:
+            for required_check in required_checks:
+                if required_check not in results:
+                    results[required_check] = ('pending', None)
 
         return results
 

--- a/tubular/github_api.py
+++ b/tubular/github_api.py
@@ -398,35 +398,6 @@ class GitHubAPI:
 
         return data
 
-    def _map_check_state(self, conclusion, status):
-        """
-        Map GitHub Check Run/Suite state to normalized value.
-        Handles race condition where status='completed' but conclusion is None.
-
-        Arguments:
-            conclusion: The conclusion field from the check (may be None)
-            status: The status field from the check (may be None)
-
-        Returns:
-            str: Normalized state value
-        """
-        # If we have a conclusion, use it (check is truly complete)
-        if conclusion is not None:
-            return conclusion.lower()
-
-        # No conclusion - look at status
-        status_value = status if status is not None else 'pending'
-
-        # Special case: 'completed' without conclusion is a race condition
-        # Treat as pending to avoid misclassifying as failure
-        if status_value.lower() == 'completed':
-            LOG.debug("Check has status='completed' but no conclusion yet - treating as pending")
-            return 'pending'
-
-        # For all other statuses (queued, in_progress, waiting, requested)
-        # return the status as-is
-        return status_value.lower()
-
     def get_validation_results(self, commit):
         """
         Return a list of validations (statuses and check runs), their results (success/failure/pending),
@@ -443,7 +414,7 @@ class GitHubAPI:
         results.update({
             status.context: (
                 status.state.lower() if status.state is not None else None,
-                status.target_url if status.target_url is not None else ''
+                status.target_url
             )
             for status in combined_status.statuses
         })
@@ -451,9 +422,9 @@ class GitHubAPI:
         check_suites = self.get_commit_check_suites(commit)
         results.update({
             suite['app']['name']: (
-                # Map check suite states using helper to handle 'completed' without conclusion
-                self._map_check_state(suite.get('conclusion'), suite.get('status')),
-                suite.get('url', '')
+                # Use status field when conclusion is None, default to 'pending' if both are None
+                (suite.get('conclusion') or suite.get('status') or 'pending').lower(),
+                suite['url']
             )
             for suite in check_suites['check_suites']
             if self.all_checks or suite['app']['name'] in required_checks
@@ -463,15 +434,14 @@ class GitHubAPI:
         check_runs = self.get_commit_check_runs(commit)
         results.update({
             suite['name']: (
-                # Map check run states using helper to handle 'completed' without conclusion
-                self._map_check_state(suite.get('conclusion'), suite.get('status')),
-                suite.get('url', '')
+                # Use status field when conclusion is None, default to 'pending' if both are None
+                (suite.get('conclusion') or suite.get('status') or 'pending').lower(),
+                suite['url']
             )
             for suite in check_runs['check_runs']
             if self.all_checks or suite['name'] in required_checks
         })
 
-        LOG.info("Retrieved {} validation result(s) for commit".format(len(results)))
         return results
 
     @backoff.on_exception(backoff.expo, (RateLimitExceededException, socket.timeout), max_tries=7,
@@ -516,30 +486,11 @@ class GitHubAPI:
         Aggregate validation results. Returns 'success' if all validations
         are 'success' or 'neutral', 'pending' if any validations are 'pending',
         'in_progress', 'queued', 'waiting', or 'requested', or 'failure' otherwise.
-        
-        This ensures that checks that are still running will cause the aggregate
-        to be 'pending', preventing deployments from proceeding while checks are
-        still in progress.
         """
-        # Safety check: empty results should not return success
-        # This is handled by _is_commit_successful but added here for safety
-        if not results:
-            LOG.warning("aggregate_validation_results called with empty results")
+        if any(state in ('pending', 'in_progress', 'queued', 'waiting', 'requested', None) for (state, url) in results.values()):
             return 'pending'
-        
-        # List of states that indicate a check is still running
-        # Includes None for cases where state hasn't been set yet
-        pending_states = {'pending', 'in_progress', 'queued', 'waiting', 'requested', None}
-        
-        # Check if any validations are still running
-        if any(state in pending_states for (state, url) in results.values()):
-            return 'pending'
-        
-        # Check if all validations passed
         if all(state in ('success', 'neutral', 'skipped') for (state, url) in results.values()):
             return 'success'
-        
-        # Otherwise, at least one check failed
         return 'failure'
 
     def _is_commit_successful(self, sha):
@@ -554,27 +505,15 @@ class GitHubAPI:
         Returns:
             tuple(bool, dict, string):
                 bool: True when the combined state equals 'success', False otherwise
-                dict: Key/values of ci_context:"url status"
+                dict: Key/values of ci_context:ci_url
                 string: The aggregate validation status of the commit
         """
         all_validations = self.filter_validation_results(self.get_validation_results(sha))
-        
-        # Return false if there are no checks so that commits whose tests haven't started yet are not valid
-        # This is critical for preventing deployments during race conditions when checks are being re-run
-        # Check this BEFORE calling aggregate_validation_results to avoid duplicate warnings
-        if len(all_validations) < 1:
-            LOG.warning(
-                "No validation checks found for commit {}. This may indicate checks haven't started yet, "
-                "or all checks are being filtered out.".format(sha[:7])
-            )
-            return (False, {}, 'no_checks')
-        
         aggregate_validation = self.aggregate_validation_results(all_validations)
 
-        # Log the aggregate status for debugging
-        LOG.info("Commit {} has aggregate status: {} ({} checks)".format(
-            sha[:7], aggregate_validation, len(all_validations)
-        ))
+        # Return false if there are no checks so that commits whose tests haven't started yet are not valid
+        if len(all_validations) < 1:
+            return (False, {})
 
         return (
             aggregate_validation == 'success',
@@ -592,7 +531,7 @@ class GitHubAPI:
         Returns:
             tuple(bool, dict):
                 bool: True if all tests have passed successfully, False otherwise
-                dict: Key/values of ci_context:"url status"
+                dict: Key/values of ci_context:ci_url
 
         Raises:
             github.GithubException.GithubException: Unknown errors from github
@@ -610,7 +549,7 @@ class GitHubAPI:
         Returns:
             tuple(bool, dict):
                 bool: True if all tests have passed successfully, False otherwise
-                dict: Key/values of ci_context:"url status"
+                dict: Key/values of ci_context:ci_url
 
         Raises:
             github.GithubException.GithubException: Unknown errors from github
@@ -633,9 +572,7 @@ class GitHubAPI:
             sha (str): The SHA of which to get the status.
 
         Returns:
-            tuple(string, dict): 
-                string: The current commit status ('success', 'pending', 'failure', etc.)
-                dict: Validation results with ci_context:"url status"
+            tuple(string, dict): the current commit status, and the results and urls of all validations
         """
 
         @backoff.on_exception(
@@ -656,15 +593,10 @@ class GitHubAPI:
         )
         def _run():
             result = self._is_commit_successful(sha)
-            # result = (success_bool, statuses_dict, aggregate_status)
-            
-            # If no checks were found, return success to avoid waiting forever
-            if result[2] == 'no_checks':
-                LOG.info("No checks found for commit {}. Polling will return success.".format(sha[:7]))
+            if result[0] == False:  # No Checks found against the Commit
+                # Returning any string other than '' will set the commit status to succeed. 
+                # Returning 'success' to avoid breaking pipeline checks in case no actions are found
                 return ("success", None)
-            
-            # Return the aggregate status and statuses dict
-            # The backoff decorator will retry if aggregate_status == 'pending'
             return (result[2], result[1])
         return _run()
 

--- a/tubular/github_api.py
+++ b/tubular/github_api.py
@@ -410,7 +410,6 @@ class GitHubAPI:
         required_checks = self.get_branch_protection_rules()
 
         results = {}
-
         combined_status = self.get_commit_combined_statuses(commit)
         results.update({
             status.context: (

--- a/tubular/github_api.py
+++ b/tubular/github_api.py
@@ -558,16 +558,18 @@ class GitHubAPI:
                 string: The aggregate validation status of the commit
         """
         all_validations = self.filter_validation_results(self.get_validation_results(sha))
-        aggregate_validation = self.aggregate_validation_results(all_validations)
-
+        
         # Return false if there are no checks so that commits whose tests haven't started yet are not valid
         # This is critical for preventing deployments during race conditions when checks are being re-run
+        # Check this BEFORE calling aggregate_validation_results to avoid duplicate warnings
         if len(all_validations) < 1:
             LOG.warning(
                 "No validation checks found for commit {}. This may indicate checks haven't started yet, "
                 "or all checks are being filtered out.".format(sha[:7])
             )
             return (False, {}, 'no_checks')
+        
+        aggregate_validation = self.aggregate_validation_results(all_validations)
 
         # Log the aggregate status for debugging
         LOG.info("Commit {} has aggregate status: {} ({} checks)".format(
@@ -657,8 +659,7 @@ class GitHubAPI:
             # result = (success_bool, statuses_dict, aggregate_status)
             
             # If no checks were found, return success to avoid waiting forever
-            # Check for both 'no_checks' (explicitly set) and '' (empty string for backward compatibility)
-            if result[2] in ('no_checks', ''):
+            if result[2] == 'no_checks':
                 LOG.info("No checks found for commit {}. Polling will return success.".format(sha[:7]))
                 return ("success", None)
             

--- a/tubular/github_api.py
+++ b/tubular/github_api.py
@@ -554,7 +554,7 @@ class GitHubAPI:
         Returns:
             tuple(bool, dict, string):
                 bool: True when the combined state equals 'success', False otherwise
-                dict: Key/values of ci_context:ci_url
+                dict: Key/values of ci_context:"url status"
                 string: The aggregate validation status of the commit
         """
         all_validations = self.filter_validation_results(self.get_validation_results(sha))
@@ -590,7 +590,7 @@ class GitHubAPI:
         Returns:
             tuple(bool, dict):
                 bool: True if all tests have passed successfully, False otherwise
-                dict: Key/values of ci_context:ci_url
+                dict: Key/values of ci_context:"url status"
 
         Raises:
             github.GithubException.GithubException: Unknown errors from github
@@ -608,7 +608,7 @@ class GitHubAPI:
         Returns:
             tuple(bool, dict):
                 bool: True if all tests have passed successfully, False otherwise
-                dict: Key/values of ci_context:ci_url
+                dict: Key/values of ci_context:"url status"
 
         Raises:
             github.GithubException.GithubException: Unknown errors from github
@@ -631,7 +631,9 @@ class GitHubAPI:
             sha (str): The SHA of which to get the status.
 
         Returns:
-            tuple(string, dict): the current commit status, and the results and urls of all validations
+            tuple(string, dict): 
+                string: The current commit status ('success', 'pending', 'failure', etc.)
+                dict: Validation results with ci_context:"url status"
         """
 
         @backoff.on_exception(

--- a/tubular/github_api.py
+++ b/tubular/github_api.py
@@ -411,11 +411,6 @@ class GitHubAPI:
 
         results = {}
 
-        # The Commit Status API (combined_status) is the legacy API and only includes
-        # statuses created via the status API. Modern GitHub Actions workflows and their
-        # individual jobs appear as Check Runs, not statuses. Since branch protection
-        # rules can require specific Check Run names (like "Unit tests successful"),
-        # we must use the Check Runs API - we cannot rely solely on the Status API.
         combined_status = self.get_commit_combined_statuses(commit)
         results.update({
             status.context: (

--- a/tubular/scripts/check_pr_tests_status.py
+++ b/tubular/scripts/check_pr_tests_status.py
@@ -59,9 +59,8 @@ LOG = logging.getLogger(__name__)
     default=sys.stdout
 )
 @click.option(
-    '--all-checks',
-    help="Check all validation contexts, whehther it is required or not",
-    is_flag=True,
+    '--all-checks/--required-checks-only',
+    help="Check all validation contexts, or only required ones.",
     default=True
 )
 @click.option(
@@ -78,12 +77,11 @@ LOG = logging.getLogger(__name__)
     '--min-checks',
     help=u"Minimum number of checks required to be present before allowing success. Set to 0 to disable.",
     default=1,
-    type=int,
+    type=click.IntRange(min=0),
 )
 @click.option(
-    '--fail-on-pending',
+    '--fail-on-pending/--no-fail-on-pending',
     help=u"Fail if any checks are still pending/in-progress. Recommended for deployment gates.",
-    is_flag=True,
     default=True
 )
 def check_tests(

--- a/tubular/scripts/check_pr_tests_status.py
+++ b/tubular/scripts/check_pr_tests_status.py
@@ -59,9 +59,10 @@ LOG = logging.getLogger(__name__)
     default=sys.stdout
 )
 @click.option(
-    '--all-checks/--required-checks-only',
-    help="Check all validation contexts, or only required ones.",
-    default=True
+    '--all-checks',
+    help="Check all validation contexts, whehther it is required or not",
+    is_flag=True,
+    default=False
 )
 @click.option(
     '--exclude-contexts',

--- a/tubular/scripts/check_pr_tests_status.py
+++ b/tubular/scripts/check_pr_tests_status.py
@@ -73,26 +73,9 @@ LOG = logging.getLogger(__name__)
     help=u"Regex defining which validation contexts to include from this status check.",
     default=None
 )
-@click.option(
-    '--min-checks',
-    help=(
-        u"Minimum number of checks required to be present before allowing success. "
-        u"BREAKING CHANGE: Now defaults to 1 (previously allowed 0 checks to pass). "
-        u"This prevents deployments during race conditions when checks haven't started yet. "
-        u"Set to 0 to restore old behavior for repos with no CI checks configured."
-    ),
-    default=1,
-    type=click.IntRange(min=0),
-)
-@click.option(
-    '--fail-on-pending/--no-fail-on-pending',
-    help=u"Fail if any checks are still pending/in-progress. Recommended for deployment gates.",
-    default=True
-)
 def check_tests(
         org, repo, token, input_file, pr_number, commit_hash,
         out_file, all_checks, exclude_contexts, include_contexts,
-        min_checks, fail_on_pending,
 ):
     """
     Check the current combined status of a GitHub PR/commit in a repo once.
@@ -136,92 +119,21 @@ def check_tests(
         sys.argv[0], git_obj, "success" if combined_status_success else "failed"
     ))
 
-    # Validate minimum check count to prevent race conditions where checks haven't started yet
-    check_count = len(test_statuses)
-    LOG.info("Found {} check(s) for {}.".format(check_count, git_obj))
-    
-    if check_count < min_checks:
-        LOG.error(
-            "DEPLOYMENT GATE FAILURE: Only {} check(s) found, but minimum of {} required. "
-            "This may indicate checks haven't started yet or a configuration issue. "
-            "For repos with no CI checks, use --min-checks=0 to allow deployment.".format(
-                check_count, min_checks
-            )
-        )
-        status_success = False
-    else:
-        ignore_list = ['GitHub Actions']
-        
-        # Track different failure types for better diagnostics
-        pending_checks = []
-        failed_checks = []
-        successful_checks = []
-        
-        for test_name, details in test_statuses.items():
-            try:
-                _url, test_status_string = details.split(" ", 1)
-            except ValueError:
-                # Malformed details string - treat as failure
-                LOG.error("Check \"{test_name}\" has malformed details: {details}".format(
-                    test_name=test_name, details=details))
-                failed_checks.append((test_name, "malformed_data"))
-                continue
-            
-            # Check for pending/in-progress states
-            # Note: 'none' handles the case where GitHub API returns None as a state value
-            if test_status_string.lower() in ["pending", "in_progress", "queued", "waiting", "requested", "none"]:
-                pending_checks.append((test_name, test_status_string))
-                LOG.info("Check \"{test_name}\" is still running: {status}".format(
-                    test_name=test_name, status=test_status_string))
-            # Check for success/skipped states
-            # Note: 'neutral' is a valid GitHub check conclusion for informational checks that
-            # complete successfully but neither pass nor fail (e.g., linting suggestions).
-            # Treating neutral as passing is consistent with aggregate_validation_results in github_api.py
-            # and prevents informational checks from blocking deployments.
-            elif test_status_string.lower() in ["success", "skipped", "neutral"]:
-                successful_checks.append(test_name)
-                LOG.info("Check \"{test_name}\" passed: {status}".format(
-                    test_name=test_name, status=test_status_string))
-            # Everything else is a failure
+    ignore_list = ['GitHub Actions']
+
+    status_success = True
+
+    for test_name, details in test_statuses.items():
+        _url, test_status_string = details.split(" ", 1)
+        test_status_success = bool(test_status_string in ["success", "skipped"])
+        if not test_status_success:
+            if test_name in ignore_list:
+                LOG.info("Ignoring failure of \"{test_name}\" because it is in the ignore list".format(
+                    test_name=test_name))
             else:
-                if test_name in ignore_list:
-                    LOG.info("Ignoring failure of \"{test_name}\" because it is in the ignore list".format(
-                        test_name=test_name))
-                    successful_checks.append(test_name)
-                else:
-                    failed_checks.append((test_name, test_status_string))
-                    LOG.error("Check \"{test_name}\" FAILED: {details}".format(
-                        test_name=test_name, details=details))
-        
-        # Log summary
-        LOG.info("Check summary: {} successful, {} pending, {} failed".format(
-            len(successful_checks), len(pending_checks), len(failed_checks)
-        ))
-        
-        # Determine overall status
-        if failed_checks:
-            LOG.error("DEPLOYMENT GATE FAILURE: {} check(s) failed: {}".format(
-                len(failed_checks), [name for name, _ in failed_checks]
-            ))
-            status_success = False
-        elif pending_checks and fail_on_pending:
-            LOG.error(
-                "DEPLOYMENT GATE FAILURE: {} check(s) still pending/in-progress: {}. "
-                "Cannot proceed to deployment while checks are running.".format(
-                    len(pending_checks), [name for name, _ in pending_checks]
-                )
-            )
-            status_success = False
-        elif pending_checks and not fail_on_pending:
-            LOG.warning(
-                "WARNING: {} check(s) still pending but --fail-on-pending is False: {}".format(
-                    len(pending_checks), [name for name, _ in pending_checks]
-                )
-            )
-            status_success = True
-        else:
-            LOG.info("All checks passed successfully.")
-            status_success = True
+                LOG.info("Commit failed due to \"{test_name}\": {details}".format(
+                    test_name=test_name, details=details))
+                status_success = False
 
     dirname = os.path.dirname(out_file.name)
     if dirname:

--- a/tubular/scripts/check_pr_tests_status.py
+++ b/tubular/scripts/check_pr_tests_status.py
@@ -75,7 +75,12 @@ LOG = logging.getLogger(__name__)
 )
 @click.option(
     '--min-checks',
-    help=u"Minimum number of checks required to be present before allowing success. Set to 0 to disable.",
+    help=(
+        u"Minimum number of checks required to be present before allowing success. "
+        u"BREAKING CHANGE: Now defaults to 1 (previously allowed 0 checks to pass). "
+        u"This prevents deployments during race conditions when checks haven't started yet. "
+        u"Set to 0 to restore old behavior for repos with no CI checks configured."
+    ),
     default=1,
     type=click.IntRange(min=0),
 )
@@ -138,7 +143,8 @@ def check_tests(
     if check_count < min_checks:
         LOG.error(
             "DEPLOYMENT GATE FAILURE: Only {} check(s) found, but minimum of {} required. "
-            "This may indicate checks haven't started yet or a configuration issue.".format(
+            "This may indicate checks haven't started yet or a configuration issue. "
+            "For repos with no CI checks, use --min-checks=0 to allow deployment.".format(
                 check_count, min_checks
             )
         )
@@ -168,6 +174,10 @@ def check_tests(
                 LOG.info("Check \"{test_name}\" is still running: {status}".format(
                     test_name=test_name, status=test_status_string))
             # Check for success/skipped states
+            # Note: 'neutral' is a valid GitHub check conclusion for informational checks that
+            # complete successfully but neither pass nor fail (e.g., linting suggestions).
+            # Treating neutral as passing is consistent with aggregate_validation_results in github_api.py
+            # and prevents informational checks from blocking deployments.
             elif test_status_string.lower() in ["success", "skipped", "neutral"]:
                 successful_checks.append(test_name)
                 LOG.info("Check \"{test_name}\" passed: {status}".format(

--- a/tubular/tests/test_github.py
+++ b/tubular/tests/test_github.py
@@ -407,6 +407,118 @@ class GitHubApiTestCase(TestCase):
         assert set(expected_contexts) == set(filtered_results.keys())
 
     @ddt.data(
+        # Test case 1: Missing required check should be added as pending
+        (
+            ['Unit tests successful', 'Quality checks'],
+            ['Quality checks'],
+            {'Unit tests successful': ('pending', None), 'Quality checks': ('success', 'some.url')},
+            False,
+        ),
+        # Test case 2: All required checks present - no changes
+        (
+            ['Unit tests successful', 'Quality checks'],
+            ['Unit tests successful', 'Quality checks'],
+            {'Unit tests successful': ('success', 'some.url'), 'Quality checks': ('success', 'some.url')},
+            False,
+        ),
+        # Test case 3: Multiple missing required checks - all added as pending
+        (
+            ['Check A', 'Check B', 'Check C'],
+            [],
+            {'Check A': ('pending', None), 'Check B': ('pending', None), 'Check C': ('pending', None)},
+            False,
+        ),
+        # Test case 4: all_checks=True with missing checks - should NOT add them
+        (
+            ['Unit tests successful'],
+            [],
+            {},
+            True,
+        ),
+        # Test case 5: No required checks configured - nothing to add
+        (
+            [],
+            [],
+            {},
+            False,
+        ),
+        # Test case 6: Mix of present and missing checks
+        (
+            ['Check A', 'Check B', 'Check C'],
+            ['Check A', 'Check C'],
+            {'Check A': ('success', 'some.url'), 'Check B': ('pending', None), 'Check C': ('failure', 'some.url')},
+            False,
+        ),
+    )
+    @ddt.unpack
+    def test_missing_required_checks_treated_as_pending(
+        self, required_checks, existing_checks, expected_results, all_checks
+    ):
+        """
+        Test that missing required checks are added as pending to block deployment.
+        
+        This validates the fix for BOMS-242 where deployments were incorrectly
+        proceeding while CI checks were still running because missing required checks
+        were being ignored.
+        """
+        with patch.object(
+                Github,
+                'get_organization',
+                return_value=Mock(name='org-mock', spec=Organization)
+        ):
+            with patch.object(Github, 'get_repo', return_value=Mock(name='repo-mock', spec=Repository)) as repo_mock:
+                api = GitHubAPI(
+                    'test-org',
+                    'test-repo',
+                    token='abc123',
+                    all_checks=all_checks
+                )
+        
+        api.log_rate_limit = Mock(return_value=None)
+        api.get_branch_protection_rules = Mock(return_value=required_checks)
+        
+        mock_combined_status = Mock(name='combined-status', spec=CommitCombinedStatus)
+        mock_combined_status.statuses = []
+        
+        for check_name in existing_checks:
+            status_state = 'success'
+            if 'failure' in expected_results.get(check_name, ('', ''))[0]:
+                status_state = 'failure'
+            elif 'pending' in expected_results.get(check_name, ('', ''))[0]:
+                status_state = 'pending'
+            
+            mock_status = Mock(name=check_name, spec=CommitStatus)
+            mock_status.context = check_name
+            mock_status.state = status_state
+            mock_status.target_url = 'some.url'
+            mock_combined_status.statuses.append(mock_status)
+        
+        commit_mock = Mock(name='commit', spec=Commit, url="some.fake.repo/")
+        commit_mock.get_combined_status.return_value = mock_combined_status
+        repo_mock.return_value.get_commit.return_value = commit_mock
+        commit_mock._requester = Mock(name='_requester')  # pylint: disable=protected-access
+        
+        commit_mock._requester.requestJsonAndCheck.return_value = (  # pylint: disable=protected-access
+            {},
+            {
+                'check_suites': [],
+                'check_runs': []
+            }
+        )
+        
+        results = api.get_validation_results('deadbeef')
+        
+        assert set(results.keys()) == set(expected_results.keys()), \
+            f"Expected checks: {set(expected_results.keys())}, Got: {set(results.keys())}"
+        
+        for check_name, (expected_state, expected_url) in expected_results.items():
+            actual_state, actual_url = results[check_name]
+            assert actual_state == expected_state, \
+                f"Check '{check_name}': expected state '{expected_state}', got '{actual_state}'"
+            assert actual_url == expected_url, \
+                f"Check '{check_name}': expected URL '{expected_url}', got '{actual_url}'"
+
+    @ddt.data(
         # 1 unique SHA should result in 1 search query and 1 PR.
         (SHAS[:1], 1, 1),
         # 18 unique SHAs should result in 1 search query and 18 PRs.

--- a/tubular/tests/test_github.py
+++ b/tubular/tests/test_github.py
@@ -236,7 +236,7 @@ class GitHubApiTestCase(TestCase):
         ('123', list(range(10)), 10, 'pending', False, False, True),
         ('123', list(range(10)), 8, 'failure', False, False, False),
         ('123', [], 0, None, False, False, False),
-        # Test new in-progress states are treated as pending by aggregate_validation_results
+        # Test in-progress states are treated as pending by aggregate_validation_results
         ('123', list(range(10)), 8, 'in_progress', False, False, False),
         ('123', list(range(10)), 8, 'queued', False, False, False),
         ('123', list(range(10)), 8, 'waiting', False, False, False),
@@ -352,10 +352,7 @@ class GitHubApiTestCase(TestCase):
         self.api.all_checks = False
         successful, statuses = self.api.check_combined_status_commit(sha)
 
-        # Verify status field was read (point 1) - status value should appear in the results
-        # The statuses dict has values like "url state", so check if status_value is in any value
         assert any(status_value.lower() in value.lower() for value in statuses.values())
-        # Verify aggregate treats it as pending (point 2)
         assert successful is False
 
     @ddt.data(

--- a/tubular/tests/test_github.py
+++ b/tubular/tests/test_github.py
@@ -235,12 +235,7 @@ class GitHubApiTestCase(TestCase):
         ('123', list(range(10)), 8, 'pending', False, False, False),
         ('123', list(range(10)), 10, 'pending', False, False, True),
         ('123', list(range(10)), 8, 'failure', False, False, False),
-        ('123', [], 0, None, False, False, False),
-        # Test in-progress states are treated as pending by aggregate_validation_results
-        ('123', list(range(10)), 8, 'in_progress', False, False, False),
-        ('123', list(range(10)), 8, 'queued', False, False, False),
-        ('123', list(range(10)), 8, 'waiting', False, False, False),
-        ('123', list(range(10)), 8, 'requested', False, False, False),
+        ('123', [], 0, None, False, False, False)
     )
     @ddt.unpack
     def test_check_combined_status_commit(
@@ -306,54 +301,6 @@ class GitHubApiTestCase(TestCase):
         assert len(statuses) == statuses_returned
         commit_mock.get_combined_status.assert_called()
         self.repo_mock.get_commit.assert_called_with(sha)
-
-    @ddt.data(
-        ('in_progress',),
-        ('queued',),
-        ('waiting',),
-        ('requested',),
-    )
-    @ddt.unpack
-    def test_status_field_fallback_and_aggregate_pending(self, status_value):
-        """
-        Test two things:
-        1. When conclusion is None, the status field is read from check suite/run
-        2. in_progress/queued/waiting/requested states are treated as pending by aggregate
-        """
-        sha = '123'
-        
-        mock_combined_status = Mock(spec=CommitCombinedStatus)
-        mock_combined_status.statuses = []
-        mock_combined_status.state = None
-        mock_combined_status.url = None
-
-        commit_mock = Mock(spec=Commit, url="some.fake.repo/")
-        commit_mock.get_combined_status.return_value = mock_combined_status
-        self.repo_mock.get_commit.return_value = commit_mock
-
-        self.api.get_branch_protection_rules = Mock(return_value=['TestApp'])
-
-        commit_mock._requester = Mock()  # pylint: disable=protected-access
-        commit_mock._requester.requestJsonAndCheck.return_value = (  # pylint: disable=protected-access
-            {},
-            {
-                'check_suites': [
-                    {
-                        'app': {'name': 'TestApp'},
-                        'conclusion': None,
-                        'status': status_value,
-                        'url': 'some.fake.repo'
-                    }
-                ],
-                'check_runs': []
-            },
-        )
-
-        self.api.all_checks = False
-        successful, statuses = self.api.check_combined_status_commit(sha)
-
-        assert any(status_value.lower() in value.lower() for value in statuses.values())
-        assert successful is False
 
     @ddt.data(
         ('', 'success', None),  # Case where no actions are found

--- a/tubular/tests/test_github.py
+++ b/tubular/tests/test_github.py
@@ -303,22 +303,22 @@ class GitHubApiTestCase(TestCase):
         self.repo_mock.get_commit.assert_called_with(sha)
 
     @ddt.data(
-        ('no_checks', 'success', None),  # Case where no checks are found
-        ('passed', 'passed', True),      # Case where checks are found and succeed
-        ('failed', 'failed', False),     # Case where checks are found and fail
+        ('', 'success', None),  # Case where no actions are found
+        ('passed', 'passed', True),    # Case where actions are found and succeed
+        ('failed', 'failed', False),   # Case where actions are found and fail
     )
     @ddt.unpack
     def test_poll_commit(self, initial_status, end_status, successful):
         url_dict = {'TravisCI': 'some url'}
         side_effects = [
-            (False, url_dict, initial_status) if initial_status == 'no_checks' else (True, url_dict, initial_status),
+            (False, url_dict, initial_status) if initial_status == '' else (True, url_dict, initial_status),
             (successful, url_dict, end_status),
         ]
         
         with patch.object(self.api, '_is_commit_successful', side_effect=side_effects) as mock_is_commit_successful:
             result = self.api._poll_commit('some sha')  # pylint: disable=protected-access
 
-            if initial_status == 'no_checks':
+            if initial_status == '':
                 # We expect the function to return immediately after the first call
                 assert result[0] == 'success'
                 assert result[1] is None
@@ -326,58 +326,6 @@ class GitHubApiTestCase(TestCase):
                 # Ensure the function processes both calls
                 assert result[0] == end_status
                 assert result[1] == url_dict
-
-    @ddt.data(
-        # Empty results - should return pending for safety
-        ({}, 'pending'),
-        # Single check states
-        ({'check1': ('success', 'url')}, 'success'),
-        ({'check1': ('failure', 'url')}, 'failure'),
-        ({'check1': ('pending', 'url')}, 'pending'),
-        ({'check1': ('in_progress', 'url')}, 'pending'),
-        ({'check1': ('queued', 'url')}, 'pending'),
-        ({'check1': ('waiting', 'url')}, 'pending'),
-        ({'check1': ('requested', 'url')}, 'pending'),
-        ({'check1': (None, 'url')}, 'pending'),
-        ({'check1': ('neutral', 'url')}, 'success'),
-        ({'check1': ('skipped', 'url')}, 'success'),
-        # Multiple checks - mixed states
-        ({'check1': ('success', 'url'), 'check2': ('success', 'url')}, 'success'),
-        ({'check1': ('success', 'url'), 'check2': ('pending', 'url')}, 'pending'),
-        ({'check1': ('success', 'url'), 'check2': ('in_progress', 'url')}, 'pending'),
-        ({'check1': ('success', 'url'), 'check2': ('failure', 'url')}, 'failure'),
-        # Pending takes precedence over failure
-        ({'check1': ('pending', 'url'), 'check2': ('failure', 'url')}, 'pending'),
-        ({'check1': ('in_progress', 'url'), 'check2': ('failure', 'url')}, 'pending'),
-    )
-    @ddt.unpack
-    def test_aggregate_validation_results(self, results, expected_status):
-        """Test aggregate_validation_results with various check states including new pending states."""
-        actual_status = self.api.aggregate_validation_results(results)
-        assert actual_status == expected_status
-
-    @ddt.data(
-        # Conclusion takes precedence when present
-        ('success', 'completed', 'success'),
-        ('failure', 'completed', 'failure'),
-        ('neutral', 'completed', 'neutral'),
-        ('skipped', 'completed', 'skipped'),
-        # status='completed' without conclusion should return 'pending' (race condition)
-        (None, 'completed', 'pending'),
-        # Other statuses without conclusion
-        (None, 'in_progress', 'in_progress'),
-        (None, 'queued', 'queued'),
-        (None, 'waiting', 'waiting'),
-        (None, 'requested', 'requested'),
-        (None, 'pending', 'pending'),
-        # Both None - default to pending
-        (None, None, 'pending'),
-    )
-    @ddt.unpack
-    def test_map_check_state(self, conclusion, status, expected_state):
-        """Test _map_check_state handles completed without conclusion race condition."""
-        actual_state = self.api._map_check_state(conclusion, status)  # pylint: disable=protected-access
-        assert actual_state == expected_state
 
     @ddt.data(
         (

--- a/tubular/tests/test_github.py
+++ b/tubular/tests/test_github.py
@@ -235,7 +235,12 @@ class GitHubApiTestCase(TestCase):
         ('123', list(range(10)), 8, 'pending', False, False, False),
         ('123', list(range(10)), 10, 'pending', False, False, True),
         ('123', list(range(10)), 8, 'failure', False, False, False),
-        ('123', [], 0, None, False, False, False)
+        ('123', [], 0, None, False, False, False),
+        # Test new in-progress states are treated as pending by aggregate_validation_results
+        ('123', list(range(10)), 8, 'in_progress', False, False, False),
+        ('123', list(range(10)), 8, 'queued', False, False, False),
+        ('123', list(range(10)), 8, 'waiting', False, False, False),
+        ('123', list(range(10)), 8, 'requested', False, False, False),
     )
     @ddt.unpack
     def test_check_combined_status_commit(
@@ -301,6 +306,57 @@ class GitHubApiTestCase(TestCase):
         assert len(statuses) == statuses_returned
         commit_mock.get_combined_status.assert_called()
         self.repo_mock.get_commit.assert_called_with(sha)
+
+    @ddt.data(
+        ('in_progress',),
+        ('queued',),
+        ('waiting',),
+        ('requested',),
+    )
+    @ddt.unpack
+    def test_status_field_fallback_and_aggregate_pending(self, status_value):
+        """
+        Test two things:
+        1. When conclusion is None, the status field is read from check suite/run
+        2. in_progress/queued/waiting/requested states are treated as pending by aggregate
+        """
+        sha = '123'
+        
+        mock_combined_status = Mock(spec=CommitCombinedStatus)
+        mock_combined_status.statuses = []
+        mock_combined_status.state = None
+        mock_combined_status.url = None
+
+        commit_mock = Mock(spec=Commit, url="some.fake.repo/")
+        commit_mock.get_combined_status.return_value = mock_combined_status
+        self.repo_mock.get_commit.return_value = commit_mock
+
+        self.api.get_branch_protection_rules = Mock(return_value=['TestApp'])
+
+        commit_mock._requester = Mock()  # pylint: disable=protected-access
+        commit_mock._requester.requestJsonAndCheck.return_value = (  # pylint: disable=protected-access
+            {},
+            {
+                'check_suites': [
+                    {
+                        'app': {'name': 'TestApp'},
+                        'conclusion': None,
+                        'status': status_value,
+                        'url': 'some.fake.repo'
+                    }
+                ],
+                'check_runs': []
+            },
+        )
+
+        self.api.all_checks = False
+        successful, statuses = self.api.check_combined_status_commit(sha)
+
+        # Verify status field was read (point 1) - status value should appear in the results
+        # The statuses dict has values like "url state", so check if status_value is in any value
+        assert any(status_value.lower() in value.lower() for value in statuses.values())
+        # Verify aggregate treats it as pending (point 2)
+        assert successful is False
 
     @ddt.data(
         ('', 'success', None),  # Case where no actions are found

--- a/tubular/tests/test_github.py
+++ b/tubular/tests/test_github.py
@@ -303,8 +303,7 @@ class GitHubApiTestCase(TestCase):
         self.repo_mock.get_commit.assert_called_with(sha)
 
     @ddt.data(
-        ('no_checks', 'success', None),  # Case where no checks are found (new sentinel)
-        ('', 'success', None),           # Case where no checks are found (legacy empty string)
+        ('no_checks', 'success', None),  # Case where no checks are found
         ('passed', 'passed', True),      # Case where checks are found and succeed
         ('failed', 'failed', False),     # Case where checks are found and fail
     )
@@ -312,14 +311,14 @@ class GitHubApiTestCase(TestCase):
     def test_poll_commit(self, initial_status, end_status, successful):
         url_dict = {'TravisCI': 'some url'}
         side_effects = [
-            (False, url_dict, initial_status) if initial_status in ('', 'no_checks') else (True, url_dict, initial_status),
+            (False, url_dict, initial_status) if initial_status == 'no_checks' else (True, url_dict, initial_status),
             (successful, url_dict, end_status),
         ]
         
         with patch.object(self.api, '_is_commit_successful', side_effect=side_effects) as mock_is_commit_successful:
             result = self.api._poll_commit('some sha')  # pylint: disable=protected-access
 
-            if initial_status in ('', 'no_checks'):
+            if initial_status == 'no_checks':
                 # We expect the function to return immediately after the first call
                 assert result[0] == 'success'
                 assert result[1] is None


### PR DESCRIPTION
### Issue Description:
Deployment gate was incorrectly allowing deployments to proceed while GitHub CI checks were still running. This happened because required checks that haven't been created yet (like "Unit tests successful" which waits for individual test shards) don't exist in GitHub's API response and were being ignored, allowing the deployment gate to pass prematurely.

### Root Cause:
In `get_validation_results()`, we only validated checks that existed in the GitHub API response. If a required check hadn't been created yet (still waiting for dependent jobs), it simply wasn't in the results dictionary, so the deployment gate considered validation complete and passed.

### Solution:
Added a simple check at the end of `get_validation_results()` to ensure ALL required checks are accounted for:

```
# If a required check is missing from the results, add it as pending to block deployment.
# This ensures we wait for ALL required checks to be created and pass.
if not self.all_checks and required_checks:
    for required_check in required_checks:
        if required_check not in results:
            results[required_check] = ('pending', None)
```
**What this does:**

- After collecting all checks from GitHub API (statuses, check suites, check runs)
- Loop through the required checks from branch protection rules
- For any required check that's missing from results, add it with status 'pending'
- This blocks deployment until the check appears and passes
- This prevents deployments from proceeding while CI checks are still running.

### Testing:
Created comprehensive test script 
[test_deployment_gate.sh](https://github.com/user-attachments/files/25946937/test_deployment_gate.sh)
 that replicates the GoCD pipeline locally and validates the fix works correctly on `edx/edx-platform` commit CI runs.

**Instructions to run the script locally:**

- export GITHUB_TOKEN=your_github_personal_access_token
- Basic usage (tests default edx-platform/release-ulmo):
`./test_deployment_gate.sh`
- Test specific commit:
 `./test_deployment_gate.sh <commit_sha>`
- Test with your fix branch:
`TUBULAR_BRANCH=<your-branch> ./test_deployment_gate.sh`

**Result:**

1. On required checks pending:
<img width="1120" height="856" alt="Screenshot 2026-03-12 172748" src="https://github.com/user-attachments/assets/925659ba-d076-4311-829f-556a3369033c" />

2 On any required check successful:
<img width="1127" height="878" alt="Screenshot 2026-03-12 172821" src="https://github.com/user-attachments/assets/96aa17fe-7dea-4701-aeb9-edf8c215a248" />

### Private JIRA Link:
[BOMS-242](https://2u-internal.atlassian.net/browse/BOMS-242)