### PR TITLE
feat: Add deletion warning notifications for expiring files

### DIFF
--- a/tubular/google_api.py
+++ b/tubular/google_api.py
@@ -578,6 +578,8 @@ class DriveApi(BaseApiClient):
         """
         List comments for a file.
 
+        This function may make multiple HTTP requests depending on how many pages the response contains.
+
         Args:
             file_id (str): Drive file ID for which to list comments.
             fields (str): comma separated list of fields to describe each comment resource in the response.
@@ -591,12 +593,25 @@ class DriveApi(BaseApiClient):
                 https://developers.google.com/drive/api/v3/handle-errors
         """
         try:
-            response = self._client.comments().list(  # pylint: disable=no-member
-                fileId=file_id,
-                fields='comments({})'.format(fields),
-                supportsAllDrives=True
-            ).execute()
-            return response.get('comments', [])
+            all_comments = []
+            extra_kwargs = {}
+            
+            while True:
+                response = self._client.comments().list(  # pylint: disable=no-member
+                    fileId=file_id,
+                    fields='nextPageToken, comments({})'.format(fields),
+                    **extra_kwargs
+                ).execute()
+                
+                page_comments = response.get('comments', [])
+                all_comments.extend(page_comments)
+                
+                if 'nextPageToken' in response and response['nextPageToken']:
+                    extra_kwargs['pageToken'] = response['nextPageToken']
+                else:
+                    break
+            
+            return all_comments
         except HttpError as exc:
             if exc.resp.status == 404:
                 # File not found or no access

--- a/tubular/google_api.py
+++ b/tubular/google_api.py
@@ -567,6 +567,41 @@ class DriveApi(BaseApiClient):
 
         return responses
 
+    @backoff.on_exception(
+        backoff.expo,
+        HttpError,
+        max_tries=BACKOFF_MAX_TRIES,
+        giveup=_fatal_code
+    )
+    def list_comments_for_file(self, file_id, fields='id, content, createdTime'):
+        """
+        List comments for a file.
+
+        Args:
+            file_id (str): Drive file ID for which to list comments.
+            fields (str): comma separated list of fields to describe each comment resource in the response.
+
+        Returns: list of comment resources (list of dict). The contents of the comment resources are dictated
+            by the `fields` arg.
+
+        Throws:
+            googleapiclient.errors.HttpError:
+                For some non-retryable 4xx or 5xx error. See the full list here:
+                https://developers.google.com/drive/api/v3/handle-errors
+        """
+        try:
+            response = self._client.comments().list(  # pylint: disable=no-member
+                fileId=file_id,
+                fields='comments({})'.format(fields),
+                supportsAllDrives=True
+            ).execute()
+            return response.get('comments', [])
+        except HttpError as exc:
+            if exc.resp.status == 404:
+                # File not found or no access
+                return []
+            raise
+
     # NOTE: Do not decorate this function with backoff since it already calls retryable methods.
     def list_permissions_for_files(self, file_ids, fields='emailAddress, role'):
         """

--- a/tubular/google_api.py
+++ b/tubular/google_api.py
@@ -570,8 +570,9 @@ class DriveApi(BaseApiClient):
     @backoff.on_exception(
         backoff.expo,
         HttpError,
-        max_tries=BACKOFF_MAX_TRIES,
-        giveup=_fatal_code
+        max_time=600,  # 10 minutes
+        giveup=lambda e: not _should_retry_google_api(e),
+        on_backoff=lambda details: _backoff_handler(details),  # pylint: disable=unnecessary-lambda
     )
     def list_comments_for_file(self, file_id, fields='id, content, createdTime'):
         """

--- a/tubular/scripts/retirement_partner_report.py
+++ b/tubular/scripts/retirement_partner_report.py
@@ -68,11 +68,15 @@ AUTH_HEADER = {}
 NOTIFICATION_MESSAGE_TEMPLATE = """
 Hello from edX. Dear {tags}, a new report listing the learners enrolled in your institution’s courses on edx.org that have requested deletion of their edX account and associated personal data within the last week has been published to Google Drive. Please access your folder to see the latest report.
 """.strip()
+# Used to verify deletion comments; must exist in DELETION_WARNING_MESSAGE_TEMPLATE
+DELETION_WARNING_PHRASE = 'will be automatically deleted'
 # Deletion warning template for files approaching expiration
 # Format variables: tags, filename, days_until_deletion, deletion_date
-DELETION_WARNING_MESSAGE_TEMPLATE = """
-Hello from edX. Dear {tags}, this is an automated notice that the retirement report file "{filename}" in your Google Drive folder will be automatically deleted in {days_until_deletion} days (on {deletion_date} UTC) as part of our data retention policy.
-""".strip()
+DELETION_WARNING_MESSAGE_TEMPLATE = (
+    'Hello from edX. Dear {tags}, this is an automated notice that the retirement report file '
+    '"{filename}" in your Google Drive folder ' + DELETION_WARNING_PHRASE +
+    ' in {days_until_deletion} days (on {deletion_date} UTC) as part of our data retention policy.'
+)
 LEARNER_CREATED_KEY = 'created'  # This key is currently required to exist in the learner
 LEARNER_ORIGINAL_USERNAME_KEY = 'original_username'  # This key is currently required to exist in the learner
 ORGS_KEY = 'orgs'
@@ -289,12 +293,12 @@ def _push_files_to_google(config, partner_filenames):
     return file_ids
 
 
-def _get_external_emails_for_partners(drive, config, partners=None):
+def _get_partner_emails(drive, config, partners=None):
     """
     Extract external email addresses from partner folder permissions.
     
     This shared helper ensures consistent handling of permissions and denied domains
-    across different notification paths (upload comments and deletion warnings).
+    across different notification paths (e.g. upload comments, deletion warnings, etc.).
     
     Args:
         drive (DriveApi): Initialized Drive API client.
@@ -337,22 +341,22 @@ def _get_external_emails_for_partners(drive, config, partners=None):
     return external_emails
 
 
-def _add_comments_to_files(config, file_ids):
+def _add_comments_to_files(config, partner_file_ids_dict):
     """
     Add comments to the uploaded csv files, triggering email notification.
 
     Args:
-        file_ids (dict): Mapping of partner names to Drive file IDs corresponding to the newly uploaded csv files.
+        partner_file_ids_dict (dict): Mapping of partner names to Drive file IDs corresponding to the newly uploaded csv files.
     """
     drive = DriveApi(config['google_secrets_file'])
     
     # Get external emails for partners with uploaded files
-    external_emails = _get_external_emails_for_partners(drive, config, partners=list(file_ids.keys()))
+    external_emails = _get_partner_emails(drive, config, partners=list(partner_file_ids_dict.keys()))
 
     file_ids_and_comments = []
     missing_poc_partners = []
 
-    for partner in file_ids:
+    for partner in partner_file_ids_dict:
         if not external_emails[partner]:
             # Check if this partner is exempt from POC requirements
             if partner in config.get('exempted_partners', []):
@@ -371,7 +375,7 @@ def _add_comments_to_files(config, file_ids):
         else:
             tag_string = ' '.join('+' + email for email in external_emails[partner])
             comment_content = NOTIFICATION_MESSAGE_TEMPLATE.format(tags=tag_string)
-            file_ids_and_comments.append((file_ids[partner], comment_content))
+            file_ids_and_comments.append((partner_file_ids_dict[partner], comment_content))
 
     if file_ids_and_comments:
         try:
@@ -389,24 +393,30 @@ def _add_comments_to_files(config, file_ids):
              .format(len(missing_poc_partners), partner_word, ', '.join('"{}"'.format(p) for p in missing_poc_partners)))
 
 
-def _check_and_warn_about_expiring_files(config):
+def _check_and_notify_about_expiring_files(config):
     """
     Check for existing files approaching their deletion date and send warning notifications.
     
     Uses configuration values:
     - deletion_warning_days: Days before deletion to send warning
-    
-    Note: age_in_days (retention period) is passed via CLI parameter --age_in_days
-    
+        
     Args:
         config (dict): Configuration dictionary containing retention settings and Drive folder mappings.
     """
+    # CLI parameter "--age_in_days" represents the retention period.
     retention_days = config.get('age_in_days', 60)
     warning_days = config.get('deletion_warning_days', 7)
-    
-    if retention_days <= 0 or warning_days <= 0 or warning_days >= retention_days:
-        LOG('File deletion warnings disabled or misconfigured. Skipping expiration check.')
-        return
+
+    if retention_days <= 0 or warning_days <= 0:
+        raise ValueError(
+            'Misconfigured retention settings: age_in_days={}, deletion_warning_days={}. '
+            'Both must be positive integers.'.format(retention_days, warning_days)
+        )
+    if warning_days >= retention_days:
+        raise ValueError(
+            'Misconfigured retention settings: deletion_warning_days ({}) must be less than '
+            'age_in_days ({}).'.format(warning_days, retention_days)
+        )
     
     LOG('Checking for files approaching deletion (retention: {} days, warning: {} days before)'.format(
         retention_days, warning_days
@@ -418,7 +428,7 @@ def _check_and_warn_about_expiring_files(config):
         warning_threshold = now - timedelta(days=(retention_days - warning_days))
         
         # Get external emails per partner using shared helper
-        external_emails = _get_external_emails_for_partners(drive, config)
+        external_emails = _get_partner_emails(drive, config)
         
         # Check files in each partner folder
         platform_name = config['partner_report_platform_name']
@@ -463,10 +473,11 @@ def _check_and_warn_about_expiring_files(config):
                     if file_created <= warning_threshold:
                         file_id = file_info.get('id')
 
-                        # Check for filename in existing comments (stable even if message wording changes)
+                        # First check if the file already has the deletion warning to avoid
+                        # duplicate comments on re-run.
                         existing_comments = drive.list_comments_for_file(file_id, fields='content')
                         has_warning = any(
-                            filename in comment.get('content', '')
+                            DELETION_WARNING_PHRASE in comment.get('content', '')
                             for comment in existing_comments
                         )
 
@@ -594,7 +605,7 @@ def generate_report(config_file, google_secrets_file, output_dir, comments, age_
         
         # Check for expiring files and send warnings if enabled
         if enable_check_expiring_files:
-            _check_and_warn_about_expiring_files(config)
+            _check_and_notify_about_expiring_files(config)
         
         report_data, all_usernames = _get_orgs_and_learners_or_exit(config)
         # If no usernames were returned, then no reports need to be generated.

--- a/tubular/scripts/retirement_partner_report.py
+++ b/tubular/scripts/retirement_partner_report.py
@@ -316,13 +316,11 @@ def _get_external_emails_for_partners(drive, config, partners=None):
         folder_ids,
         fields='emailAddress',
     )
-    
     # Create a mapping of partners to a list of permissions dicts
     permissions = {
         partner: partner_folders_to_permissions[config['partner_folder_mapping'][partner]]
         for partner in partners
     }
-    
     # Filter out denied addresses and flatten to just email addresses
     external_emails = {
         partner: [

--- a/tubular/scripts/retirement_partner_report.py
+++ b/tubular/scripts/retirement_partner_report.py
@@ -6,10 +6,12 @@ Command-line script to drive the partner reporting part of the retirement proces
 """
 
 from collections import defaultdict, OrderedDict
-from datetime import date
+from datetime import date, datetime, timedelta
+from dateutil.parser import parse
 from functools import partial
 import logging
 import os
+from pytz import UTC
 import sys
 import unicodedata
 import unicodecsv as csv
@@ -66,7 +68,11 @@ AUTH_HEADER = {}
 NOTIFICATION_MESSAGE_TEMPLATE = """
 Hello from edX. Dear {tags}, a new report listing the learners enrolled in your institution’s courses on edx.org that have requested deletion of their edX account and associated personal data within the last week has been published to Google Drive. Please access your folder to see the latest report.
 """.strip()
-
+# Deletion warning template for files approaching expiration
+# Format variables: tags, filename, days_until_deletion, deletion_date
+DELETION_WARNING_MESSAGE_TEMPLATE = """
+Hello from edX. Dear {tags}, this is an automated notice that the retirement report file "{filename}" in your Google Drive folder will be automatically deleted in {days_until_deletion} days (on {deletion_date} UTC) as part of our data retention policy.
+""".strip()
 LEARNER_CREATED_KEY = 'created'  # This key is currently required to exist in the learner
 LEARNER_ORIGINAL_USERNAME_KEY = 'original_username'  # This key is currently required to exist in the learner
 ORGS_KEY = 'orgs'
@@ -356,6 +362,131 @@ def _add_comments_to_files(config, file_ids):
              .format(len(missing_poc_partners), partner_word, ', '.join('"{}"'.format(p) for p in missing_poc_partners)))
 
 
+def _check_and_warn_about_expiring_files(config):
+    """
+    Check for existing files approaching their deletion date and send warning notifications.
+    
+    Uses configuration values:
+    - deletion_warning_days: Days before deletion to send warning
+    
+    Note: age_in_days (retention period) is passed via CLI parameter --age_in_days
+    
+    Args:
+        config (dict): Configuration dictionary containing retention settings and Drive folder mappings.
+    """
+    retention_days = config.get('age_in_days', 60)
+    warning_days = config.get('deletion_warning_days', 7)
+    
+    if retention_days <= 0 or warning_days <= 0 or warning_days >= retention_days:
+        LOG('File deletion warnings disabled or misconfigured. Skipping expiration check.')
+        return
+    
+    LOG('Checking for files approaching deletion (retention: {} days, warning: {} days before)'.format(
+        retention_days, warning_days
+    ))
+    
+    try:
+        drive = DriveApi(config['google_secrets_file'])
+        now = datetime.now(UTC)
+        warning_threshold = now - timedelta(days=(retention_days - warning_days))
+        
+        # Get folder permissions (same as in _add_comments_to_files)
+        partner_folders_to_permissions = drive.list_permissions_for_files(
+            config['partner_folder_mapping'].values(),
+            fields='emailAddress',
+        )
+        
+        # Get external emails per partner
+        permissions = {
+            partner: partner_folders_to_permissions[config['partner_folder_mapping'][partner]]
+            for partner in config['partner_folder_mapping']
+        }
+        
+        external_emails = {
+            partner: [
+                perm['emailAddress']
+                for perm in permissions[partner]
+                if not any(
+                    perm['emailAddress'].lower().endswith(denied_domain.lower())
+                    for denied_domain in config['denied_notification_domains']
+                )
+            ]
+            for partner in permissions
+        }
+        
+        # Check files in each partner folder
+        platform_name = config['partner_report_platform_name']
+        file_prefix = '{}_{}'.format(REPORTING_FILENAME_PREFIX, platform_name)
+        
+        for partner in config['partner_folder_mapping']:
+            folder_id = config['partner_folder_mapping'][partner]
+            
+            # Skip if no external POC (unless exempt)
+            if not external_emails[partner]:
+                if partner not in config.get('exempted_partners', []):
+                    LOG('WARNING: Partner "{}" has no POC for deletion warnings'.format(partner))
+                continue
+            
+            try:
+                files = drive.walk_files(
+                    folder_id,
+                    file_fields='id, name, createdTime',
+                    mimetype='text/csv',
+                    recurse=False
+                )
+                
+                for file_info in files:
+                    filename = file_info.get('name', '')
+                    
+                    if not filename.startswith(file_prefix):
+                        continue
+                    
+                    created_time_str = file_info.get('createdTime')
+                    if not created_time_str:
+                        LOG('WARNING: File {} has no creation time, skipping'.format(filename))
+                        continue
+                    
+                    file_created = parse(created_time_str)
+                    if file_created.tzinfo is None:
+                        file_created = file_created.replace(tzinfo=UTC)
+                    
+                    if file_created <= warning_threshold:
+                        file_id = file_info.get('id')
+                        
+                        # Check for filename in existing comments (stable even if message wording changes)
+                        existing_comments = drive.list_comments_for_file(file_id, fields='content')
+                        has_warning = any(
+                            filename in comment.get('content', '')
+                            for comment in existing_comments
+                        )
+                        
+                        if has_warning:
+                            LOG('File {} already has deletion warning, skipping'.format(filename))
+                            continue
+                        
+                        days_until_deletion = retention_days - (now - file_created).days
+                        deletion_date = (file_created + timedelta(days=retention_days)).strftime('%Y-%m-%d')
+                        
+                        tag_string = ' '.join('+' + email for email in external_emails[partner])
+                        comment_content = DELETION_WARNING_MESSAGE_TEMPLATE.format(
+                            tags=tag_string,
+                            filename=filename,
+                            days_until_deletion=days_until_deletion,
+                            deletion_date=deletion_date
+                        )
+                        
+                        drive.create_comments_for_files([(file_id, comment_content)])
+                        LOG('Sent deletion warning for file: {} ({} days until deletion)'.format(
+                            filename, days_until_deletion
+                        ))
+                        
+            except Exception as exc:  # pylint: disable=broad-except
+                LOG('WARNING: Error checking files for partner "{}": {}'.format(partner, exc))
+                
+    except Exception as exc:  # pylint: disable=broad-except
+        LOG('WARNING: Error in deletion warning check: {}. Continuing with report generation.'.format(exc))
+
+
 @click.command("generate_report")
 @click.option(
     '--config_file',
@@ -374,7 +505,24 @@ def _add_comments_to_files(config, file_ids):
     default=True,
     help='Do or skip adding notification comments to the reports.'
 )
-def generate_report(config_file, google_secrets_file, output_dir, comments):
+@click.option(
+    '--check_expiring_files/--no_check_expiring_files',
+    default=True,
+    help='Do or skip checking for files approaching deletion and sending warnings.'
+)
+@click.option(
+    '--age_in_days',
+    type=int,
+    default=None,
+    help='Number of days before files are deleted (matches cleanup job AGE_IN_DAYS).'
+)
+@click.option(
+    '--deletion_warning_days',
+    type=int,
+    default=None,
+    help='Number of days before deletion to send warning notification (overrides config file value).'
+)
+def generate_report(config_file, google_secrets_file, output_dir, comments, check_expiring_files, age_in_days, deletion_warning_days):
     """
     Retrieves a JWT token as the retirement service learner, then performs the reporting process as that user.
 
@@ -382,6 +530,7 @@ def generate_report(config_file, google_secrets_file, output_dir, comments):
     - Gets the users in the LMS reporting queue and the partners they need to be reported to
     - Generates a single report per partner
     - Pushes the reports to Google Drive
+    - Checks for old files and sends deletion warnings if configured
     - On success tells LMS to remove the users who succeeded from the reporting queue
     """
     LOG('Starting partner report using config file {} and Google config {}'.format(config_file, google_secrets_file))
@@ -398,8 +547,20 @@ def generate_report(config_file, google_secrets_file, output_dir, comments):
             FAIL(ERR_NO_OUTPUT_DIR, 'No output_dir passed in or path does not exist.')
 
         config = CONFIG_WITH_DRIVE_OR_EXIT(config_file, google_secrets_file)
+        
+        # Override retention/warning days from CLI if provided
+        if age_in_days is not None:
+            config['age_in_days'] = age_in_days
+        if deletion_warning_days is not None:
+            config['deletion_warning_days'] = deletion_warning_days
+        
         SETUP_LMS_OR_EXIT(config)
         _config_drive_folder_map_or_exit(config)
+        
+        # Check for expiring files and send warnings if enabled
+        if check_expiring_files:
+            _check_and_warn_about_expiring_files(config)
+        
         report_data, all_usernames = _get_orgs_and_learners_or_exit(config)
         # If no usernames were returned, then no reports need to be generated.
         if all_usernames:

--- a/tubular/scripts/retirement_partner_report.py
+++ b/tubular/scripts/retirement_partner_report.py
@@ -442,39 +442,60 @@ def _check_and_warn_about_expiring_files(config):
                     mimetype='text/csv',
                     recurse=False
                 )
-                
+
+                pending_comments = []
+
                 for file_info in files:
                     filename = file_info.get('name', '')
-                    
+
                     if not filename.startswith(file_prefix):
                         continue
-                    
+
                     created_time_str = file_info.get('createdTime')
                     if not created_time_str:
                         LOG('WARNING: File {} has no creation time, skipping'.format(filename))
                         continue
-                    
+
                     file_created = parse(created_time_str)
                     if file_created.tzinfo is None:
                         file_created = file_created.replace(tzinfo=UTC)
-                    
+                    else:
+                        file_created = file_created.astimezone(UTC)
+
                     if file_created <= warning_threshold:
                         file_id = file_info.get('id')
-                        
+
                         # Check for filename in existing comments (stable even if message wording changes)
                         existing_comments = drive.list_comments_for_file(file_id, fields='content')
                         has_warning = any(
                             filename in comment.get('content', '')
                             for comment in existing_comments
                         )
-                        
+
                         if has_warning:
                             LOG('File {} already has deletion warning, skipping'.format(filename))
                             continue
-                        
-                        days_until_deletion = retention_days - (now - file_created).days
-                        deletion_date = (file_created + timedelta(days=retention_days)).strftime('%Y-%m-%d')
-                        
+
+                        deletion_datetime = file_created + timedelta(days=retention_days)
+                        # Use total_seconds-based math to avoid .days flooring off-by-one
+                        seconds_until_deletion = (deletion_datetime - now).total_seconds()
+                        days_until_deletion = int(seconds_until_deletion / 86400)
+
+                        if days_until_deletion <= 0:
+                            LOG('WARNING: File {} is already past its retention period, skipping warning'.format(filename))
+                            continue
+
+                        if days_until_deletion > warning_days:
+                            # File is older than warning_threshold but not yet in the warning window;
+                            # this shouldn't normally happen but guard against clock skew or config changes.
+                            LOG('File {} has {} days until deletion, outside warning window, skipping'.format(
+                                filename, days_until_deletion
+                            ))
+                            continue
+
+                        # deletion_datetime is already UTC; format as a UTC date
+                        deletion_date = deletion_datetime.strftime('%Y-%m-%d')
+
                         tag_string = ' '.join('+' + email for email in external_emails[partner])
                         comment_content = DELETION_WARNING_MESSAGE_TEMPLATE.format(
                             tags=tag_string,
@@ -482,12 +503,15 @@ def _check_and_warn_about_expiring_files(config):
                             days_until_deletion=days_until_deletion,
                             deletion_date=deletion_date
                         )
-                        
-                        drive.create_comments_for_files([(file_id, comment_content)])
-                        LOG('Sent deletion warning for file: {} ({} days until deletion)'.format(
+                        pending_comments.append((file_id, comment_content))
+                        LOG('Queuing deletion warning for file: {} ({} days until deletion)'.format(
                             filename, days_until_deletion
                         ))
-                        
+
+                if pending_comments:
+                    drive.create_comments_for_files(pending_comments)
+                    LOG('Sent {} deletion warning(s) for partner "{}"'.format(len(pending_comments), partner))
+
             except Exception as exc:  # pylint: disable=broad-except
                 LOG('WARNING: Error checking files for partner "{}": {}'.format(partner, exc))
                 

--- a/tubular/scripts/retirement_partner_report.py
+++ b/tubular/scripts/retirement_partner_report.py
@@ -538,11 +538,6 @@ def _check_and_warn_about_expiring_files(config):
     help='Do or skip adding notification comments to the reports.'
 )
 @click.option(
-    '--check_expiring_files/--no_check_expiring_files',
-    default=True,
-    help='Do or skip checking for files approaching deletion and sending warnings.'
-)
-@click.option(
     '--age_in_days',
     type=int,
     default=None,
@@ -554,7 +549,17 @@ def _check_and_warn_about_expiring_files(config):
     default=None,
     help='Number of days before deletion to send warning notification (overrides config file value).'
 )
-def generate_report(config_file, google_secrets_file, output_dir, comments, check_expiring_files, age_in_days, deletion_warning_days):
+@click.option(
+    '--enable_check_expiring_files',
+    type=click.BOOL,
+    default=False,
+    help=(
+        'Enable expiring file checks and deletion warning notifications for GDPR partner reports. '
+        'If set to true, the script will identify files nearing deletion and notify partners. '
+    ),
+    show_default=True,
+)
+def generate_report(config_file, google_secrets_file, output_dir, comments, age_in_days, deletion_warning_days, enable_check_expiring_files):
     """
     Retrieves a JWT token as the retirement service learner, then performs the reporting process as that user.
 
@@ -590,7 +595,7 @@ def generate_report(config_file, google_secrets_file, output_dir, comments, chec
         _config_drive_folder_map_or_exit(config)
         
         # Check for expiring files and send warnings if enabled
-        if check_expiring_files:
+        if enable_check_expiring_files:
             _check_and_warn_about_expiring_files(config)
         
         report_data, all_usernames = _get_orgs_and_learners_or_exit(config)

--- a/tubular/scripts/retirement_partner_report.py
+++ b/tubular/scripts/retirement_partner_report.py
@@ -289,27 +289,41 @@ def _push_files_to_google(config, partner_filenames):
     return file_ids
 
 
-def _add_comments_to_files(config, file_ids):
+def _get_external_emails_for_partners(drive, config, partners=None):
     """
-    Add comments to the uploaded csv files, triggering email notification.
-
+    Extract external email addresses from partner folder permissions.
+    
+    This shared helper ensures consistent handling of permissions and denied domains
+    across different notification paths (upload comments and deletion warnings).
+    
     Args:
-        file_ids (dict): Mapping of partner names to Drive file IDs corresponding to the newly uploaded csv files.
+        drive (DriveApi): Initialized Drive API client.
+        config (dict): Configuration dictionary containing partner_folder_mapping and denied_notification_domains.
+        partners (list, optional): List of specific partner names to process. If None, processes all partners
+                                   in partner_folder_mapping.
+    
+    Returns:
+        dict: Mapping of partner names to lists of external email addresses (denied domains filtered out).
     """
-    drive = DriveApi(config['google_secrets_file'])
-
+    # Default to all partners if not specified
+    if partners is None:
+        partners = list(config['partner_folder_mapping'].keys())
+    
+    # Get unique folder IDs for the specified partners
+    folder_ids = {config['partner_folder_mapping'][partner] for partner in partners}
+    
     partner_folders_to_permissions = drive.list_permissions_for_files(
-        config['partner_folder_mapping'].values(),
+        folder_ids,
         fields='emailAddress',
     )
-
-    # create a mapping of partners to a list of permissions dicts:
+    
+    # Create a mapping of partners to a list of permissions dicts
     permissions = {
         partner: partner_folders_to_permissions[config['partner_folder_mapping'][partner]]
-        for partner in file_ids
+        for partner in partners
     }
-
-    # throw out all denied addresses, and flatten the permissions dicts to just the email:
+    
+    # Filter out denied addresses and flatten to just email addresses
     external_emails = {
         partner: [
             perm['emailAddress']
@@ -321,6 +335,21 @@ def _add_comments_to_files(config, file_ids):
         ]
         for partner in permissions
     }
+    
+    return external_emails
+
+
+def _add_comments_to_files(config, file_ids):
+    """
+    Add comments to the uploaded csv files, triggering email notification.
+
+    Args:
+        file_ids (dict): Mapping of partner names to Drive file IDs corresponding to the newly uploaded csv files.
+    """
+    drive = DriveApi(config['google_secrets_file'])
+    
+    # Get external emails for partners with uploaded files
+    external_emails = _get_external_emails_for_partners(drive, config, partners=list(file_ids.keys()))
 
     file_ids_and_comments = []
     missing_poc_partners = []
@@ -390,29 +419,8 @@ def _check_and_warn_about_expiring_files(config):
         now = datetime.now(UTC)
         warning_threshold = now - timedelta(days=(retention_days - warning_days))
         
-        # Get folder permissions (same as in _add_comments_to_files)
-        partner_folders_to_permissions = drive.list_permissions_for_files(
-            config['partner_folder_mapping'].values(),
-            fields='emailAddress',
-        )
-        
-        # Get external emails per partner
-        permissions = {
-            partner: partner_folders_to_permissions[config['partner_folder_mapping'][partner]]
-            for partner in config['partner_folder_mapping']
-        }
-        
-        external_emails = {
-            partner: [
-                perm['emailAddress']
-                for perm in permissions[partner]
-                if not any(
-                    perm['emailAddress'].lower().endswith(denied_domain.lower())
-                    for denied_domain in config['denied_notification_domains']
-                )
-            ]
-            for partner in permissions
-        }
+        # Get external emails per partner using shared helper
+        external_emails = _get_external_emails_for_partners(drive, config)
         
         # Check files in each partner folder
         platform_name = config['partner_report_platform_name']

--- a/tubular/tests/retirement_helpers.py
+++ b/tubular/tests/retirement_helpers.py
@@ -84,6 +84,7 @@ def fake_config_file(f, orgs=None, fetch_ecom_segment_id=False, exempted_partner
         },
         'segment_workspace_slug': 'test_slug',
         'segment_auth_token': 'fakeauthtoken',
+        'deletion_warning_days': 7,
     }
 
     if fetch_ecom_segment_id:

--- a/tubular/tests/test_google_api.py
+++ b/tubular/tests/test_google_api.py
@@ -820,3 +820,126 @@ ETag: "etag/bird"\r\n\r\n{
                 mimetype=None,
                 recurse=True
             )
+
+    @patch('tubular.google_api.service_account.Credentials.from_service_account_file', return_value=None)
+    def test_list_comments_single_page(self, mock_from_service_account_file):  # pylint: disable=unused-argument
+        """
+        Test listing comments for a file when all comments fit on a single page.
+        """
+        fake_file_id = 'fake-file-id'
+        comments_response = json.dumps({
+            'comments': [
+                {
+                    'id': 'comment-1',
+                    'content': 'First comment',
+                    'createdTime': '2026-03-01T10:00:00.000Z'
+                },
+                {
+                    'id': 'comment-2',
+                    'content': 'Second comment',
+                    'createdTime': '2026-03-02T11:00:00.000Z'
+                }
+            ]
+        }).encode('utf-8')
+        
+        http_mock_sequence = HttpMockSequence([
+            ({'status': '200'}, self.mock_discovery_response_content),
+            ({'status': '200'}, comments_response),
+        ])
+        test_client = DriveApi('non-existent-secrets.json', http=http_mock_sequence)
+        comments = test_client.list_comments_for_file(fake_file_id)
+        
+        self.assertEqual(len(comments), 2)
+        self.assertEqual(comments[0]['id'], 'comment-1')
+        self.assertEqual(comments[0]['content'], 'First comment')
+        self.assertEqual(comments[1]['id'], 'comment-2')
+        self.assertEqual(comments[1]['content'], 'Second comment')
+
+    @patch('tubular.google_api.service_account.Credentials.from_service_account_file', return_value=None)
+    def test_list_comments_pagination(self, mock_from_service_account_file):  # pylint: disable=unused-argument
+        """
+        Test listing comments for a file when pagination is required (multiple pages).
+        """
+        fake_file_id = 'fake-file-id'
+        # First page response with nextPageToken
+        first_page_response = json.dumps({
+            'comments': [
+                {
+                    'id': 'comment-1',
+                    'content': 'First comment',
+                    'createdTime': '2026-03-01T10:00:00.000Z'
+                },
+                {
+                    'id': 'comment-2',
+                    'content': 'Second comment',
+                    'createdTime': '2026-03-02T11:00:00.000Z'
+                }
+            ],
+            'nextPageToken': 'token-page-2'
+        }).encode('utf-8')
+        
+        second_page_response = json.dumps({
+            'comments': [
+                {
+                    'id': 'comment-3',
+                    'content': 'Third comment',
+                    'createdTime': '2026-03-03T12:00:00.000Z'
+                }
+            ],
+            'nextPageToken': 'token-page-3'
+        }).encode('utf-8')
+        
+        third_page_response = json.dumps({
+            'comments': [
+                {
+                    'id': 'comment-4',
+                    'content': 'Fourth comment',
+                    'createdTime': '2026-03-04T13:00:00.000Z'
+                }
+            ]
+        }).encode('utf-8')
+        
+        http_mock_sequence = HttpMockSequence([
+            ({'status': '200'}, self.mock_discovery_response_content),
+            ({'status': '200'}, first_page_response),
+            ({'status': '200'}, second_page_response),
+            ({'status': '200'}, third_page_response),
+        ])
+        test_client = DriveApi('non-existent-secrets.json', http=http_mock_sequence)
+        comments = test_client.list_comments_for_file(fake_file_id)
+        
+        # Should have all comments from all pages
+        self.assertEqual(len(comments), 4)
+        self.assertEqual(comments[0]['id'], 'comment-1')
+        self.assertEqual(comments[1]['id'], 'comment-2')
+        self.assertEqual(comments[2]['id'], 'comment-3')
+        self.assertEqual(comments[3]['id'], 'comment-4')
+
+    @patch('tubular.google_api.service_account.Credentials.from_service_account_file', return_value=None)
+    def test_list_comments_file_not_found(self, mock_from_service_account_file):  # pylint: disable=unused-argument
+        """
+        Test listing comments for a non-existent file returns empty list.
+        """
+        fake_file_id = 'non-existent-file-id'
+        error_response = json.dumps({
+            'error': {
+                'code': 404,
+                'message': 'File not found',
+                'errors': [
+                    {
+                        'domain': 'global',
+                        'reason': 'notFound',
+                        'message': 'File not found',
+                    }
+                ]
+            }
+        }).encode('utf-8')
+        
+        http_mock_sequence = HttpMockSequence([
+            ({'status': '200'}, self.mock_discovery_response_content),
+            ({'status': '404'}, error_response),
+        ])
+        test_client = DriveApi('non-existent-secrets.json', http=http_mock_sequence)
+        comments = test_client.list_comments_for_file(fake_file_id)
+        
+        self.assertEqual(comments, [])

--- a/tubular/tests/test_retirement_partner_report.py
+++ b/tubular/tests/test_retirement_partner_report.py
@@ -7,11 +7,13 @@ Test the retire_one_learner.py script
 import csv
 import os
 import unicodedata
-from datetime import date
+from datetime import date, datetime, timedelta
 import time
 
+import pytest
 from click.testing import CliRunner
 from mock import DEFAULT, patch
+from pytz import UTC
 from six import PY2, itervalues
 
 from tubular.scripts.retirement_partner_report import (
@@ -28,6 +30,7 @@ from tubular.scripts.retirement_partner_report import (
     ERR_SETUP_FAILED,
     ERR_UNKNOWN_ORG,
     ERR_DRIVE_LISTING,
+    DELETION_WARNING_PHRASE,
     LEARNER_CREATED_KEY,
     LEARNER_ORIGINAL_USERNAME_KEY,
     ORGS_CONFIG_FIELD_HEADINGS_KEY,
@@ -40,6 +43,7 @@ from tubular.scripts.retirement_partner_report import (
     generate_report,
     _generate_report_files_or_exit,  # pylint: disable=protected-access
     _get_orgs_and_learners_or_exit,  # pylint: disable=protected-access
+    _check_and_notify_about_expiring_files,  # pylint: disable=protected-access
 )
 
 from tubular.tests.retirement_helpers import fake_config_file, fake_google_secrets_file, flatten_partner_list, FAKE_ORGS, TEST_PLATFORM_NAME
@@ -943,3 +947,161 @@ def test_file_content_custom_headings():
             # Verify default field values are not present
             assert username not in file_content
             assert DELETION_TIME not in file_content
+
+
+# -----------------------------------------------------------------------
+# Tests for _check_and_notify_about_expiring_files
+# -----------------------------------------------------------------------
+
+def _make_expiring_config(age_in_days=60, deletion_warning_days=7):
+    """Minimal config dict for expiring-file tests."""
+    return {
+        'google_secrets_file': 'fake.json',
+        'partner_report_platform_name': 'fakename',
+        'age_in_days': age_in_days,
+        'deletion_warning_days': deletion_warning_days,
+        'denied_notification_domains': ['@edx.org'],
+        'partner_folder_mapping': {'Org1X': 'folder_Org1X'},
+        'exempted_partners': [],
+    }
+
+
+def test_check_expiring_files_raises_on_zero_retention():
+    """ValueError is raised if age_in_days is 0."""
+    config = _make_expiring_config(age_in_days=0, deletion_warning_days=7)
+    with pytest.raises(ValueError, match='Misconfigured retention settings'):
+        _check_and_notify_about_expiring_files(config)
+
+
+def test_check_expiring_files_raises_on_zero_warning_days():
+    """ValueError is raised if deletion_warning_days is 0."""
+    config = _make_expiring_config(age_in_days=60, deletion_warning_days=0)
+    with pytest.raises(ValueError, match='Misconfigured retention settings'):
+        _check_and_notify_about_expiring_files(config)
+
+
+def test_check_expiring_files_raises_when_warning_days_gte_retention():
+    """ValueError is raised if deletion_warning_days >= age_in_days."""
+    config = _make_expiring_config(age_in_days=7, deletion_warning_days=7)
+    with pytest.raises(ValueError, match='must be less than'):
+        _check_and_notify_about_expiring_files(config)
+
+
+@patch('tubular.google_api.DriveApi.__init__')
+@patch('tubular.google_api.DriveApi.list_permissions_for_files')
+@patch('tubular.google_api.DriveApi.walk_files')
+@patch('tubular.google_api.DriveApi.list_comments_for_file')
+@patch('tubular.google_api.DriveApi.create_comments_for_files')
+def test_check_expiring_files_skips_already_warned(*args):
+    """Files that already have a deletion warning comment are skipped."""
+    mock_create_comments = args[0]
+    mock_list_comments = args[1]
+    mock_walk_files = args[2]
+    mock_list_permissions = args[3]
+    mock_driveapi = args[4]
+
+    mock_driveapi.return_value = None
+    mock_list_permissions.return_value = {
+        'folder_Org1X': [{'emailAddress': 'poc@example.com'}]
+    }
+    old_time = (datetime.now(UTC) - timedelta(days=55)).strftime('%Y-%m-%dT%H:%M:%SZ')
+    mock_walk_files.return_value = [
+        {'name': 'user_retirement_fakename_Org1X_2026-01-01.csv', 'id': 'file1', 'createdTime': old_time}
+    ]
+    mock_list_comments.return_value = [{'content': 'This file will be automatically deleted soon'}]
+
+    config = _make_expiring_config()
+    _check_and_notify_about_expiring_files(config)
+
+    mock_create_comments.assert_not_called()
+
+
+@patch('tubular.google_api.DriveApi.__init__')
+@patch('tubular.google_api.DriveApi.list_permissions_for_files')
+@patch('tubular.google_api.DriveApi.walk_files')
+@patch('tubular.google_api.DriveApi.list_comments_for_file')
+@patch('tubular.google_api.DriveApi.create_comments_for_files')
+def test_check_expiring_files_queues_warning_for_expiring_file(*args):
+    """Deletion warning is posted for a file in the warning window with no prior warning."""
+    mock_create_comments = args[0]
+    mock_list_comments = args[1]
+    mock_walk_files = args[2]
+    mock_list_permissions = args[3]
+    mock_driveapi = args[4]
+
+    mock_driveapi.return_value = None
+    mock_list_permissions.return_value = {
+        'folder_Org1X': [{'emailAddress': 'poc@example.com'}]
+    }
+    old_time = (datetime.now(UTC) - timedelta(days=55)).strftime('%Y-%m-%dT%H:%M:%SZ')
+    mock_walk_files.return_value = [
+        {'name': 'user_retirement_fakename_Org1X_2026-01-01.csv', 'id': 'file1', 'createdTime': old_time}
+    ]
+    mock_list_comments.return_value = []
+
+    config = _make_expiring_config()
+    _check_and_notify_about_expiring_files(config)
+
+    mock_create_comments.assert_called_once()
+    posted_comments = mock_create_comments.call_args[0][0]
+    assert len(posted_comments) == 1
+    file_id, content = posted_comments[0]
+    assert file_id == 'file1'
+    assert DELETION_WARNING_PHRASE in content
+    assert '+poc@example.com' in content
+
+
+@patch('tubular.google_api.DriveApi.__init__')
+@patch('tubular.google_api.DriveApi.list_permissions_for_files')
+@patch('tubular.google_api.DriveApi.walk_files')
+@patch('tubular.scripts.retirement_partner_report._check_and_notify_about_expiring_files')
+@patch('tubular.edx_api.BaseApiClient.get_access_token')
+@patch.multiple(
+    'tubular.edx_api.LmsApi',
+    retirement_partner_report=DEFAULT,
+    retirement_partner_cleanup=DEFAULT
+)
+def test_enable_check_expiring_files_false_does_not_call_check(*args, **kwargs):
+    """When enable_check_expiring_files=False, _check_and_notify_about_expiring_files is never called."""
+    mock_get_access_token = args[0]
+    mock_check_expiring = args[1]
+    mock_walk_files = args[2]
+    mock_list_permissions = args[3]
+    mock_driveapi = args[4]
+    mock_retirement_report = kwargs['retirement_partner_report']
+    mock_retirement_cleanup = kwargs['retirement_partner_cleanup']
+
+    mock_get_access_token.return_value = ('THIS_IS_A_JWT', None)
+    mock_driveapi.return_value = None
+    mock_list_permissions.return_value = {
+        'folder' + partner: [{'emailAddress': 'poc@example.com'}]
+        for partner in flatten_partner_list(FAKE_ORGS.values())
+    }
+    mock_walk_files.return_value = [
+        {'name': partner, 'id': 'folder' + partner}
+        for partner in flatten_partner_list(FAKE_ORGS.values())
+    ]
+    mock_retirement_report.return_value = []
+    mock_retirement_cleanup.return_value = None
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open(TEST_CONFIG_YML_NAME, 'w') as config_f:
+            fake_config_file(config_f)
+        with open(TEST_GOOGLE_SECRETS_FILENAME, 'w') as secrets_f:
+            fake_google_secrets_file(secrets_f)
+        tmp_output_dir = 'test_output_dir'
+        os.mkdir(tmp_output_dir)
+
+        result = runner.invoke(
+            generate_report,
+            args=[
+                '--config_file', TEST_CONFIG_YML_NAME,
+                '--google_secrets_file', TEST_GOOGLE_SECRETS_FILENAME,
+                '--output_dir', tmp_output_dir,
+                '--enable_check_expiring_files', 'false',
+            ]
+        )
+
+    assert result.exit_code == 0
+    mock_check_expiring.assert_not_called()


### PR DESCRIPTION
### Overview

This PR adds a “deletion warning” notification path to the partner retirement reporting workflow, intended to alert external POCs when previously-uploaded GDPR report CSVs are approaching their retention-based deletion date.

**Changes:**

- Adds deletion_warning_days to config scaffolding.
- Extends retirement_partner_report.py to optionally scan Drive for near-expiry report files and post warning comments.
- Adds a new Drive API helper list_comments_for_file to support idempotency checks before posting warnings.

**JIRA ticket**

- https://2u-internal.atlassian.net/browse/BOMS-398

**Related PR:**

- https://github.com/edx/jenkins-job-dsl/pull/1830
- https://github.com/edx/edx-internal/pull/14150