### PR TITLE
[DO NOT MERGE]feat: Add options for MIME type and prefix filtering in report deletion script

### DIFF
--- a/tubular/scripts/delete_expired_partner_gdpr_reports.py
+++ b/tubular/scripts/delete_expired_partner_gdpr_reports.py
@@ -90,8 +90,18 @@ def _config_or_exit(config_file, google_secrets_file):
     ),
     show_default=True,
 )
+@click.option(
+    '--mimetype',
+    default=None,
+    help='MIME type of files to delete (optional). If not specified, files of all types will be deleted.'
+)
+@click.option(
+    '--prefix',
+    default=None,
+    help='Prefix filter for files to delete. If not specified, uses "{REPORTING_FILENAME_PREFIX}_{partner_report_platform_name}".'
+)
 def delete_expired_reports(
-    config_file, google_secrets_file, age_in_days, as_user_account
+    config_file, google_secrets_file, age_in_days, as_user_account, mimetype, prefix
 ):
     """
     Performs the partner report deletion as needed.
@@ -117,11 +127,18 @@ def delete_expired_reports(
             config['google_secrets_file'], as_user_account=as_user_account
         )
         LOG('DriveApi configured')
+        
+        # Use provided prefix or default to the configured pattern
+        # Treat empty string same as None (use default)
+        file_prefix = prefix if prefix else "{}_{}".format(
+            REPORTING_FILENAME_PREFIX, config['partner_report_platform_name']
+        )
+        
         drive.delete_files_older_than(
             config['drive_partners_folder'],
             delete_before_dt,
-            mimetype='text/csv',
-            prefix="{}_{}".format(REPORTING_FILENAME_PREFIX, config['partner_report_platform_name'])
+            mimetype=mimetype,
+            prefix=file_prefix
         )
         LOG('Partner report deletion complete')
     except Exception as exc:  # pylint: disable=broad-except

--- a/tubular/scripts/delete_expired_partner_gdpr_reports.py
+++ b/tubular/scripts/delete_expired_partner_gdpr_reports.py
@@ -127,13 +127,13 @@ def delete_expired_reports(
             config['google_secrets_file'], as_user_account=as_user_account
         )
         LOG('DriveApi configured')
-        
+
         # Use provided prefix or default to the configured pattern
         # Treat empty string same as None (use default)
         file_prefix = prefix if prefix else "{}_{}".format(
             REPORTING_FILENAME_PREFIX, config['partner_report_platform_name']
         )
-        
+
         drive.delete_files_older_than(
             config['drive_partners_folder'],
             delete_before_dt,

--- a/tubular/tests/test_delete_expired_reports.py
+++ b/tubular/tests/test_delete_expired_reports.py
@@ -25,7 +25,7 @@ TEST_CONFIG_FILENAME = 'test_config.yml'
 TEST_GOOGLE_SECRETS_FILENAME = 'test_google_secrets.json'
 
 
-def _call_script(age_in_days=1, expect_success=True):
+def _call_script(age_in_days=1, mimetype='text/csv', prefix=None, expect_success=True):
     """
     Call the report deletion script with a generic, temporary config file.
     Returns the CliRunner.invoke results
@@ -37,16 +37,24 @@ def _call_script(age_in_days=1, expect_success=True):
         with open(TEST_GOOGLE_SECRETS_FILENAME, 'w') as secrets_f:
             fake_google_secrets_file(secrets_f)
 
+        args = [
+            '--config_file',
+            TEST_CONFIG_FILENAME,
+            '--google_secrets_file',
+            TEST_GOOGLE_SECRETS_FILENAME,
+            '--age_in_days',
+            age_in_days
+        ]
+        
+        if mimetype:
+            args.extend(['--mimetype', mimetype])
+        
+        if prefix:
+            args.extend(['--prefix', prefix])
+
         result = runner.invoke(
             delete_expired_reports,
-            args=[
-                '--config_file',
-                TEST_CONFIG_FILENAME,
-                '--google_secrets_file',
-                TEST_GOOGLE_SECRETS_FILENAME,
-                '--age_in_days',
-                age_in_days
-            ]
+            args=args
         )
 
         print(result)

--- a/tubular/tests/test_delete_expired_reports.py
+++ b/tubular/tests/test_delete_expired_reports.py
@@ -46,10 +46,10 @@ def _call_script(age_in_days=1, mimetype='text/csv', prefix=None, expect_success
             age_in_days
         ]
         
-        if mimetype:
+        if mimetype is not None:
             args.extend(['--mimetype', mimetype])
         
-        if prefix:
+        if prefix is not None:
             args.extend(['--prefix', prefix])
 
         result = runner.invoke(


### PR DESCRIPTION
### Description:

This PR updates the GDPR partner report deletion CLI script to support configurable filtering when selecting Google Drive files for deletion.

Changes:

Adds --mimetype CLI option to control which Drive file MIME types are eligible for deletion.
Adds --prefix CLI option to control which filename prefixes are eligible for deletion, with a computed default.


**Related PR**

- Merge before this PR get merge - https://github.com/edx/jenkins-job-dsl/pull/1834