### PR TITLE
feat: added enable_delete_notification flag

### DIFF
--- a/tubular/scripts/delete_expired_partner_gdpr_reports.py
+++ b/tubular/scripts/delete_expired_partner_gdpr_reports.py
@@ -94,7 +94,11 @@ def _config_or_exit(config_file, google_secrets_file):
     '--enable_delete_notification',
     type=click.BOOL,
     default=False,
-    help='Enable logging of delete notifications for GDPR partner reports.',
+    help=(
+        'Feature flag to enable deletion notifications for GDPR partner reports. '
+        'Currently logs intent only; future implementation will send actual notifications. '
+        'See BOMS-398 for details.'
+    ),
     show_default=True,
 )
 def delete_expired_reports(

--- a/tubular/scripts/delete_expired_partner_gdpr_reports.py
+++ b/tubular/scripts/delete_expired_partner_gdpr_reports.py
@@ -90,8 +90,15 @@ def _config_or_exit(config_file, google_secrets_file):
     ),
     show_default=True,
 )
+@click.option(
+    '--enable_delete_notification',
+    type=bool,
+    default=False,
+    help='Enable logging of delete notifications for GDPR partner reports.',
+    show_default=True,
+)
 def delete_expired_reports(
-    config_file, google_secrets_file, age_in_days, as_user_account
+    config_file, google_secrets_file, age_in_days, as_user_account, enable_delete_notification
 ):
     """
     Performs the partner report deletion as needed.
@@ -99,6 +106,11 @@ def delete_expired_reports(
     LOG('Starting partner report deletion using config file "{}", Google config "{}", and {} days back'.format(
         config_file, google_secrets_file, age_in_days
     ))
+
+    if enable_delete_notification:
+        LOG('Delete notification enabled - would send notifications for deleted reports')
+    else:
+        LOG('Delete notification disabled')
 
     if not config_file:
         FAIL(ERR_NO_CONFIG, 'No config file passed in.')

--- a/tubular/scripts/delete_expired_partner_gdpr_reports.py
+++ b/tubular/scripts/delete_expired_partner_gdpr_reports.py
@@ -92,7 +92,7 @@ def _config_or_exit(config_file, google_secrets_file):
 )
 @click.option(
     '--enable_delete_notification',
-    type=bool,
+    type=click.BOOL,
     default=False,
     help='Enable logging of delete notifications for GDPR partner reports.',
     show_default=True,


### PR DESCRIPTION
### Description

Adds a new CLI option to control whether delete-notification logging is enabled when running the GDPR partner report cleanup script.
This changes will help to validate the flag value and eventually this will be used to wrap delete notification.

- This adds the flag infrastructure
- It currently only logs intent (doesn't send actual notifications yet)
- Future work will implement the actual notification logic

**Changes:**

Introduces a new --enable_delete_notification option on delete_expired_reports.
Logs whether delete notifications are enabled/disabled at script start.

**Related PR:**

- https://github.com/edx/edx-internal/pull/14081 - Merge this first
- https://github.com/edx/jenkins-job-dsl/pull/1835

**JIRA ticket**
https://2u-internal.atlassian.net/browse/BOMS-398