### PR TITLE
feat: add retirement certificate deletion functionality to LmsApi and update retirement pipeline

### DIFF
--- a/tubular/edx_api.py
+++ b/tubular/edx_api.py
@@ -319,6 +319,19 @@ class LmsApi(BaseApiClient):
         return self._request('POST', api_url, json=data)
 
     @_retry_lms_api()
+    def retirement_retire_certificates(self, learner):
+        """
+        Deletes S3 certificate files and marks GeneratedCertificate records as
+        deleted for the given retired learner.
+
+        Calls the per-user certificate retirement endpoint provided by
+        edx-arch-experiments: POST /api/certificates/v1/retire_certs_s3_for_user
+        """
+        data = {'username': learner['original_username']}
+        api_url = self.get_api_url('api/certificates/v1/retire_certs_s3_for_user')
+        return self._request('POST', api_url, json=data)
+
+    @_retry_lms_api()
     def retirement_partner_queue(self, learner):
         """
         Calls LMS to add the given user to the retirement reporting queue

--- a/tubular/scripts/retire_one_learner.py
+++ b/tubular/scripts/retire_one_learner.py
@@ -18,6 +18,7 @@ retirement_pipeline:
     - ['RETIRING_EMAIL_LISTS', 'EMAIL_LISTS_COMPLETE', 'LMS', 'retirement_retire_mailings']
     - ['RETIRING_ENROLLMENTS', 'ENROLLMENTS_COMPLETE', 'LMS', 'retirement_unenroll']
     - ['RETIRING_LMS', 'LMS_COMPLETE', 'LMS', 'retirement_lms_retire']
+    - ['RETIRING_CERTIFICATES', 'CERTIFICATES_COMPLETE', 'LMS', 'retirement_retire_certificates']
 """
 
 import logging

--- a/tubular/tests/test_edx_api.py
+++ b/tubular/tests/test_edx_api.py
@@ -166,6 +166,11 @@ class TestLmsApi(OAuth2Mixin, unittest.TestCase):
             'mock_method': 'retirement_partner_queue',
             'method': 'PUT',
         },
+        {
+            'api_url': 'api/certificates/v1/retire_certs_s3_for_user',
+            'mock_method': 'retirement_retire_certificates',
+            'method': 'POST',
+        },
     )
     @unpack
     @patch.multiple(
@@ -178,6 +183,7 @@ class TestLmsApi(OAuth2Mixin, unittest.TestCase):
         retirement_lms_retire_misc=DEFAULT,
         retirement_lms_retire=DEFAULT,
         retirement_partner_queue=DEFAULT,
+        retirement_retire_certificates=DEFAULT,
     )
     def test_learner_retirement(self, api_url, mock_method, method, **kwargs):
         json_data = {


### PR DESCRIPTION
### Description:

Adds an LMS API client call for retiring/deleting certificate artifacts and updates the example learner-retirement pipeline to include the new step.

**Changes:**

Added LmsApi.retirement_retire_certificates() to call the LMS endpoint that retires certificate S3 files for a user.
Updated the retire_one_learner.py example YAML pipeline to include a certificates retirement state.

**Related PR :**

- https://github.com/edx/edx-arch-experiments/pull/1202
- https://github.com/edx/edx-internal/pull/14325

**Jira ticket:**

- https://2u-internal.atlassian.net/browse/BOMS-488
