### PR TITLE
fix: correct username key in retirement certificate API request

### DIFF
--- a/tubular/edx_api.py
+++ b/tubular/edx_api.py
@@ -327,7 +327,7 @@ class LmsApi(BaseApiClient):
         Calls the per-user certificate retirement endpoint provided by
         edx-arch-experiments: POST /api/certificates/v1/retire_certs_s3_for_user
         """
-        data = {'username': learner['original_username']}
+        data = {'username': learner['user']['username']}
         api_url = self.get_api_url('api/certificates/v1/retire_certs_s3_for_user')
         return self._request('POST', api_url, json=data)
 

--- a/tubular/tests/test_edx_api.py
+++ b/tubular/tests/test_edx_api.py
@@ -206,6 +206,8 @@ class TestLmsApi(OAuth2Mixin, unittest.TestCase):
             match=[matchers.json_params_matcher(json_data)]
         )
         self.lms_api.retirement_retire_certificates(learner)
+        self.assertEqual(len(responses.calls), 1)
+
 
     @patch.object(edx_api.LmsApi, 'retirement_partner_report')
     def test_retirement_partner_report(self, mock_method):

--- a/tubular/tests/test_edx_api.py
+++ b/tubular/tests/test_edx_api.py
@@ -166,11 +166,6 @@ class TestLmsApi(OAuth2Mixin, unittest.TestCase):
             'mock_method': 'retirement_partner_queue',
             'method': 'PUT',
         },
-        {
-            'api_url': 'api/certificates/v1/retire_certs_s3_for_user',
-            'mock_method': 'retirement_retire_certificates',
-            'method': 'POST',
-        },
     )
     @unpack
     @patch.multiple(
@@ -183,7 +178,6 @@ class TestLmsApi(OAuth2Mixin, unittest.TestCase):
         retirement_lms_retire_misc=DEFAULT,
         retirement_lms_retire=DEFAULT,
         retirement_partner_queue=DEFAULT,
-        retirement_retire_certificates=DEFAULT,
     )
     def test_learner_retirement(self, api_url, mock_method, method, **kwargs):
         json_data = {
@@ -196,6 +190,22 @@ class TestLmsApi(OAuth2Mixin, unittest.TestCase):
         )
         getattr(self.lms_api, mock_method)(get_fake_user_retirement(original_username=FAKE_ORIGINAL_USERNAME))
         kwargs[mock_method].assert_called_once_with(get_fake_user_retirement(original_username=FAKE_ORIGINAL_USERNAME))
+
+    @responses.activate
+    def test_retirement_retire_certificates(self):
+        fake_retired_username = 'retired__user_asdf123'
+        learner = get_fake_user_retirement(
+            original_username=FAKE_ORIGINAL_USERNAME,
+            current_username=fake_retired_username,
+        )
+        json_data = {'username': fake_retired_username}
+        responses.add(
+            POST,
+            urljoin(self.lms_base_url, 'api/certificates/v1/retire_certs_s3_for_user/'),
+            json={'username': fake_retired_username, 'processed': 0, 'failed': []},
+            match=[matchers.json_params_matcher(json_data)]
+        )
+        self.lms_api.retirement_retire_certificates(learner)
 
     @patch.object(edx_api.LmsApi, 'retirement_partner_report')
     def test_retirement_partner_report(self, mock_method):


### PR DESCRIPTION
### Summary
Fixes a 400 Bad Request error when tubular calls the retire_certs_s3_for_user endpoint during learner retirement.

**Problem**
[retirement_retire_certificates] was sending [learner['original_username']] (e.g. johndoe) to the [POST /api/certificates/v1/retire_certs_s3_for_user] endpoint. However, that endpoint requires the username to start with retired__user_ prefix (as a safety check to prevent accidental deletion for active users).

By the time RETIRING_CERTIFICATES step runs, the LMS has already renamed [auth_user.username] to retired__user_<hash>. So [original_username] no longer matches any auth_user record and fails the prefix validation, returning 400.

**Change**
Changed to send [learner['user']['username'] instead, which reflects the current [auth_user.username] value — already renamed to retired__user_* by an earlier pipeline step.

JIRA ticket:
https://2u-internal.atlassian.net/browse/BOMS-558