### PR TITLE
feat: update Jenkins properties file generation to use learner IDs for filenames

### DIFF
--- a/tubular/jenkins.py
+++ b/tubular/jenkins.py
@@ -34,17 +34,22 @@ def export_learner_job_properties(learners, directory):
     Creates a Jenkins properties file for each learner in order to make
     a retirement slave job for each learner.
 
+    The properties file is named using the learner's unique identifier to
+    prevent exposing sensitive user information in job logs or titles.
+
     Args:
         learners (list of dicts): List of learners for which to create properties files.
+            Each dict must contain the learner's username and unique identifier.
         directory (str): Directory in which to create the properties files.
     """
     _recreate_directory(directory)
 
     for learner in learners:
-        learner_name = learner['original_username'].lower()
-        filename = os.path.join(directory, 'learner_retire_{}'.format(learner_name))
+        learner_id = learner['user']['id']
+        filename = os.path.join(directory, 'learner_retire_{}'.format(learner_id))
         with open(filename, 'w') as learner_prop_file:
             learner_prop_file.write('RETIREMENT_USERNAME={}\n'.format(learner['original_username']))
+            learner_prop_file.write('RETIREMENT_USER_ID={}\n'.format(learner_id))
 
 
 def _poll_giveup(data):

--- a/tubular/scripts/retire_one_learner.py
+++ b/tubular/scripts/retire_one_learner.py
@@ -89,9 +89,13 @@ def _get_learner_state_index_or_exit(learner, config):
 
         return learner_state_index
     except KeyError:
-        FAIL(ERR_BAD_LEARNER, 'Bad learner response missing current_state or state_name: {}'.format(learner))
+        FAIL(ERR_BAD_LEARNER, 'Bad learner response missing current_state or state_name for user ID: {}'.format(
+            learner.get('user', {}).get('id')
+        ))
     except ValueError:
-        FAIL(ERR_UNKNOWN_STATE, 'Unknown learner retirement state for learner: {}'.format(learner))
+        FAIL(ERR_UNKNOWN_STATE, 'Unknown learner retirement state for user ID: {}'.format(
+            learner.get('user', {}).get('id')
+        ))
 
 
 def _config_retirement_pipeline(config):
@@ -122,10 +126,9 @@ def _get_learner_and_state_index_or_exit(config, username, user_id=None):
         learner_state_index = _get_learner_state_index_or_exit(learner, config)
         return learner, learner_state_index
     except HttpDoesNotExistException:
-        identifier = user_id if user_id else username
         FAIL(ERR_BAD_LEARNER, 'Learner {} not found. Please check that the learner is present in '
                               'UserRetirementStatus, is not already retired, '
-                              'and is in an appropriate state to be acted upon.'.format(identifier))
+                              'and is in an appropriate state to be acted upon.'.format(user_id))
     except Exception as exc:  # pylint: disable=broad-except
         FAIL_EXCEPTION(ERR_SETUP_FAILED, 'Unexpected error fetching user state!', str(exc))
 
@@ -139,7 +142,9 @@ def _get_ecom_segment_id(config, learner):
     try:
         return config['ECOMMERCE'].get_tracking_key(learner)
     except HttpDoesNotExistException:
-        LOG('Learner {} not found in Ecommerce. Setting Ecommerce Segment ID to None'.format(learner))
+        LOG('Learner with user ID {} not found in Ecommerce. Setting Ecommerce Segment ID to None'.format(
+            learner.get('user', {}).get('id')
+        ))
         return None
     except Exception as exc:  # pylint: disable=broad-except
         FAIL_EXCEPTION(ERR_SETUP_FAILED, 'Unexpected error fetching Ecommerce tracking id!', str(exc))
@@ -167,8 +172,7 @@ def retire_learner(
     Retrieves a JWT token as the retirement service learner, then performs the retirement process as
     defined in WORKING_STATE_ORDER
     """
-    identifier = user_id if user_id else username
-    LOG('Starting learner retirement for user {} using config file {}'.format(identifier, config_file))
+    LOG('Starting learner retirement for user {} using config file {}'.format(user_id, config_file))
 
     if not config_file:
         FAIL(ERR_BAD_CONFIG, 'No config file passed in.')
@@ -212,7 +216,7 @@ def retire_learner(
             LOG('Progressing to state {}'.format(end_state))
 
         config['LMS'].update_learner_retirement_state(username, COMPLETE_STATE, 'Learner retirement complete.')
-        LOG('Retirement complete for learner with user ID {}'.format(identifier))
+        LOG('Retirement complete for learner with user ID {}'.format(user_id))
     except Exception as exc:  # pylint: disable=broad-except
         exc_msg = _get_error_str_from_exception(exc)
 

--- a/tubular/scripts/retire_one_learner.py
+++ b/tubular/scripts/retire_one_learner.py
@@ -111,7 +111,7 @@ def _config_retirement_pipeline(config):
         config['all_states'].append(end)
 
 
-def _get_learner_and_state_index_or_exit(config, username):
+def _get_learner_and_state_index_or_exit(config, username, user_id=None):
     """
     Double-checks the current learner state, contacting LMS, and maps that state to its
     index in the pipeline. Exits out if the learner is in an invalid state or not found
@@ -122,9 +122,10 @@ def _get_learner_and_state_index_or_exit(config, username):
         learner_state_index = _get_learner_state_index_or_exit(learner, config)
         return learner, learner_state_index
     except HttpDoesNotExistException:
+        identifier = user_id if user_id else username
         FAIL(ERR_BAD_LEARNER, 'Learner {} not found. Please check that the learner is present in '
                               'UserRetirementStatus, is not already retired, '
-                              'and is in an appropriate state to be acted upon.'.format(username))
+                              'and is in an appropriate state to be acted upon.'.format(identifier))
     except Exception as exc:  # pylint: disable=broad-except
         FAIL_EXCEPTION(ERR_SETUP_FAILED, 'Unexpected error fetching user state!', str(exc))
 
@@ -150,18 +151,24 @@ def _get_ecom_segment_id(config, learner):
     help='The original username of the user to retire'
 )
 @click.option(
+    '--user_id',
+    help='The unique user ID of the user to retire'
+)
+@click.option(
     '--config_file',
     help='File in which YAML config exists that overrides all other params.'
 )
 def retire_learner(
         username,
+        user_id,
         config_file
 ):
     """
     Retrieves a JWT token as the retirement service learner, then performs the retirement process as
     defined in WORKING_STATE_ORDER
     """
-    LOG('Starting learner retirement for {} using config file {}'.format(username, config_file))
+    identifier = user_id if user_id else username
+    LOG('Starting learner retirement for user {} using config file {}'.format(identifier, config_file))
 
     if not config_file:
         FAIL(ERR_BAD_CONFIG, 'No config file passed in.')
@@ -170,7 +177,7 @@ def retire_learner(
     _config_retirement_pipeline(config)
     SETUP_ALL_APIS_OR_EXIT(config)
 
-    learner, learner_state_index = _get_learner_and_state_index_or_exit(config, username)
+    learner, learner_state_index = _get_learner_and_state_index_or_exit(config, username, user_id=user_id)
 
     if config.get('fetch_ecommerce_segment_id', False):
         learner['ecommerce_segment_id'] = _get_ecom_segment_id(config, learner)
@@ -205,7 +212,7 @@ def retire_learner(
             LOG('Progressing to state {}'.format(end_state))
 
         config['LMS'].update_learner_retirement_state(username, COMPLETE_STATE, 'Learner retirement complete.')
-        LOG('Retirement complete for learner {}'.format(username))
+        LOG('Retirement complete for learner with user ID {}'.format(identifier))
     except Exception as exc:  # pylint: disable=broad-except
         exc_msg = _get_error_str_from_exception(exc)
 

--- a/tubular/scripts/retire_one_learner.py
+++ b/tubular/scripts/retire_one_learner.py
@@ -157,7 +157,7 @@ def _get_ecom_segment_id(config, learner):
 )
 @click.option(
     '--user_id',
-    help='The unique user ID of the user to retire'
+    help='The LMS database user ID, used for identification in logs and job titles instead of username'
 )
 @click.option(
     '--config_file',

--- a/tubular/tests/test_get_learners_to_retire.py
+++ b/tubular/tests/test_get_learners_to_retire.py
@@ -56,8 +56,8 @@ def test_success(*args, **kwargs):
 
     mock_get_access_token.return_value = ('THIS_IS_A_JWT', None)
     mock_get_learners_to_retire.return_value = [
-        get_fake_user_retirement(original_username='test_user1'),
-        get_fake_user_retirement(original_username='test_user2'),
+        get_fake_user_retirement(original_username='test_user1', user_id=123),
+        get_fake_user_retirement(original_username='test_user2', user_id=456),
     ]
 
     result = _call_script(2)

--- a/tubular/tests/test_jenkins.py
+++ b/tubular/tests/test_jenkins.py
@@ -60,10 +60,12 @@ class TestProperties(unittest.TestCase):
     def test_properties_files(self):
         learners = [
             {
-                'original_username': 'learnerA'
+                'original_username': 'learnerA',
+                'user': {'id': 123},
             },
             {
-                'original_username': 'learnerB'
+                'original_username': 'learnerB',
+                'user': {'id': 456},
             },
         ]
         open_mocker = mock_open()
@@ -71,11 +73,13 @@ class TestProperties(unittest.TestCase):
             jenkins._recreate_directory = Mock()  # pylint: disable=protected-access
             jenkins.export_learner_job_properties(learners, "tmpdir")
         jenkins._recreate_directory.assert_called_once()  # pylint: disable=protected-access
-        self.assertIn(call('tmpdir/learner_retire_learnera', 'w'), open_mocker.call_args_list)
-        self.assertIn(call('tmpdir/learner_retire_learnerb', 'w'), open_mocker.call_args_list)
+        self.assertIn(call('tmpdir/learner_retire_123', 'w'), open_mocker.call_args_list)
+        self.assertIn(call('tmpdir/learner_retire_456', 'w'), open_mocker.call_args_list)
         handle = open_mocker()
         self.assertIn(call('RETIREMENT_USERNAME=learnerA\n'), handle.write.call_args_list)
         self.assertIn(call('RETIREMENT_USERNAME=learnerB\n'), handle.write.call_args_list)
+        self.assertIn(call('RETIREMENT_USER_ID=123\n'), handle.write.call_args_list)
+        self.assertIn(call('RETIREMENT_USER_ID=456\n'), handle.write.call_args_list)
 
 
 @ddt.ddt

--- a/tubular/tests/test_retire_one_learner.py
+++ b/tubular/tests/test_retire_one_learner.py
@@ -22,7 +22,7 @@ from tubular.tests.retirement_helpers import (
 )
 
 
-def _call_script(username, fetch_ecom_segment_id=False, user_id=None):
+def _call_script(username, fetch_ecom_segment_id=False, user_id=9009):
     """
     Call the retired learner script with the given username and a generic, temporary config file.
     Returns the CliRunner.invoke results
@@ -114,7 +114,7 @@ def test_user_does_not_exist(*args, **kwargs):
 def test_bad_config():
     username = 'test_username'
     runner = CliRunner()
-    result = runner.invoke(retire_learner, args=['--username', username, '--config_file', 'does_not_exist.yml'])
+    result = runner.invoke(retire_learner, args=['--username', username, '--user_id', '9009', '--config_file', 'does_not_exist.yml'])
     assert result.exit_code == ERR_BAD_CONFIG
     assert 'does_not_exist.yml' in result.output
 

--- a/tubular/tests/test_retire_one_learner.py
+++ b/tubular/tests/test_retire_one_learner.py
@@ -22,7 +22,7 @@ from tubular.tests.retirement_helpers import (
 )
 
 
-def _call_script(username, fetch_ecom_segment_id=False):
+def _call_script(username, fetch_ecom_segment_id=False, user_id=None):
     """
     Call the retired learner script with the given username and a generic, temporary config file.
     Returns the CliRunner.invoke results
@@ -31,7 +31,10 @@ def _call_script(username, fetch_ecom_segment_id=False):
     with runner.isolated_filesystem():
         with open('test_config.yml', 'w') as f:
             fake_config_file(f, fetch_ecom_segment_id=fetch_ecom_segment_id)
-        result = runner.invoke(retire_learner, args=['--username', username, '--config_file', 'test_config.yml'])
+        args = ['--username', username, '--config_file', 'test_config.yml']
+        if user_id:
+            args.extend(['--user_id', str(user_id)])
+        result = runner.invoke(retire_learner, args=args)
     print(result)
     print(result.output)
     return result
@@ -60,9 +63,9 @@ def test_successful_retirement(*args, **kwargs):
     mock_lms_retire = kwargs['retirement_lms_retire']
 
     mock_get_access_token.return_value = ('THIS_IS_A_JWT', None)
-    mock_get_retirement_state.return_value = get_fake_user_retirement(original_username=username)
+    mock_get_retirement_state.return_value = get_fake_user_retirement(original_username=username, user_id=12345)
 
-    result = _call_script(username, fetch_ecom_segment_id=True)
+    result = _call_script(username, fetch_ecom_segment_id=True, user_id=12345)
 
     # Called once per API we instantiate (LMS, ECommerce, Credentials)
     assert mock_get_access_token.call_count == 3
@@ -79,7 +82,7 @@ def test_successful_retirement(*args, **kwargs):
         mock_call.assert_called_once_with(mock_get_retirement_state.return_value)
 
     assert result.exit_code == 0
-    assert 'Retirement complete' in result.output
+    assert 'Retirement complete for learner with user ID 12345' in result.output
 
 
 @patch('tubular.edx_api.BaseApiClient.get_access_token')


### PR DESCRIPTION
## Summary
This PR updates the user retirement workflow to use the learner's unique user ID in logs and Jenkins job property files, reducing exposure of usernames in retirement job execution and improving traceability.

## Changes

**Retirement Script (retire_one_learner.py)**
Added a new optional --user_id CLI parameter.
Updated logging to use the user ID when available instead of the username.
Enhanced learner lookup error messages to display the user ID when provided.
Passed the user ID through the retirement flow for consistent logging and error reporting.
Updated completion logs to reference the user ID.

**Jenkins Properties Generation (jenkins.py)**
Changed retirement property file naming from username-based to user ID-based naming.
Added RETIREMENT_USER_ID to generated Jenkins property files.
Retained RETIREMENT_USERNAME for backward compatibility with existing retirement processes.

## Title
https://2u-internal.atlassian.net/browse/BOMS-593