### PR TITLE
feat: update retire_learner method to use replace_usernames for username mapping

### DIFF
--- a/tubular/edx_api.py
+++ b/tubular/edx_api.py
@@ -449,11 +449,15 @@ class CredentialsApi(BaseApiClient):
     @_retry_lms_api()
     def retire_learner(self, learner):
         """
-        Performs the learner retirement step for Credentials
+        Performs the learner retirement step for Credentials.
+
+        The Credentials service currently exposes username replacement via
+        /api/v2/replace_usernames/, so retirement in this service maps the
+        original username to the learner's retired username.
         """
-        data = {'username': learner['original_username']}
-        api_url = self.get_api_url('user/retire')
-        return self._request('POST', api_url, json=data)
+        original_username = learner['original_username']
+        retired_username = learner.get('retired_username') or learner.get('user', {}).get('username')
+        return self.replace_usernames([{original_username: retired_username}])
 
     def replace_usernames(self, username_mappings):
         """

--- a/tubular/tests/test_edx_api.py
+++ b/tubular/tests/test_edx_api.py
@@ -430,21 +430,12 @@ class TestCredentialApi(OAuth2Mixin, unittest.TestCase):
             'the_client_secret'
         )
 
-    @patch.object(edx_api.CredentialsApi, 'retire_learner')
-    def test_retire_learner(self, mock_method):
-        json_data = {
-            'username': FAKE_ORIGINAL_USERNAME
-        }
-        responses.add(
-            POST,
-            urljoin(self.credentials_base_url, 'user/retire/'),
-            match=[matchers.json_params_matcher(json_data)]
-        )
-        self.credentials_api.retire_learner(
-            learner=get_fake_user_retirement(original_username=FAKE_ORIGINAL_USERNAME)
-        )
-        mock_method.assert_called_once_with(
-            learner=get_fake_user_retirement(original_username=FAKE_ORIGINAL_USERNAME)
+    @patch.object(edx_api.CredentialsApi, 'replace_usernames')
+    def test_retire_learner(self, mock_replace_usernames):
+        learner = get_fake_user_retirement(original_username=FAKE_ORIGINAL_USERNAME)
+        self.credentials_api.retire_learner(learner=learner)
+        mock_replace_usernames.assert_called_once_with(
+            [{FAKE_ORIGINAL_USERNAME: learner['retired_username']}]
         )
 
     @patch.object(edx_api.CredentialsApi, 'replace_usernames')


### PR DESCRIPTION
### Overview

This PR updates the Credentials retirement flow to perform username retirement via the existing replace_usernames endpoint (mapping original → retired username) instead of posting to the legacy user/retire path.

**Changes:**

Update CredentialsApi.retire_learner to call replace_usernames with an original→retired username mapping.
Update unit test coverage to assert retire_learner delegates to replace_usernames.

**Related PR:**

- https://github.com/edx/edx-internal/pull/14625

**JIRA ticket:**
https://2u-internal.atlassian.net/browse/BOMS-674