### PR TITLE
fix: run datadog-ci in the MFE checkout to restore GitHub code links

### DIFF
--- a/tubular/scripts/frontend_utils.py
+++ b/tubular/scripts/frontend_utils.py
@@ -5,6 +5,7 @@ single and multi deployment scripts DRY.
 import io
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -16,6 +17,7 @@ import backoff
 import CloudFlare
 import yaml
 from git import Repo
+from git.exc import InvalidGitRepositoryError, NoSuchPathError
 
 # Add top-level module path to sys.path before importing tubular code.
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -25,6 +27,23 @@ from tubular.scripts.helpers import _log, _fail  # pylint: disable=wrong-import-
 
 MAX_TRIES = 3
 
+# datadog-ci warns and exits zero when it cannot attach git data, so the return code
+# never surfaces this. Without git data Datadog cannot link a stack frame to GitHub.
+DATADOG_GIT_WARNINGS = (
+    'error occured while invoking git',  # sic -- datadog-ci's own spelling
+    'No tracked files found',
+    'Could not attach git data',
+)
+
+# Owner and repo from a github.com remote, scp-style (git@github.com:edx/foo.git) or
+# URL (https://github.com/edx/foo). Anything else is left to DATADOG_REPOSITORY_URL.
+GITHUB_REMOTE = re.compile(r'github\.com[:/]([^/]+)/([^/]+?)(?:\.git)?/?$')
+
+
+def normalize_github_url(remote_url):
+    """ Convert a git remote into the https URL Datadog expects, or None if unusable. """
+    match = GITHUB_REMOTE.search(remote_url or '')
+    return 'https://github.com/{}/{}'.format(*match.groups()) if match else None
 
 
 class FrontendUtils:
@@ -243,7 +262,10 @@ class FrontendDeployer(FrontendUtils):
                 ))
 
     def _upload_js_sourcemaps_config(self):
-        """ Retrieve config related to uploading JS sourcemaps """
+        """
+        Retrieve config related to uploading JS sourcemaps. Returns the repository URL
+        override too, so ``get_app_config`` -- which reads git HEAD -- is called once.
+        """
         app_config = self.get_app_config()
         datadog_api_key = os.environ.get('DATADOG_API_KEY')
         if not datadog_api_key:
@@ -251,50 +273,81 @@ class FrontendDeployer(FrontendUtils):
             # before executing the Datadog CLI. The Datadog documentation suggests using a dedicated Datadog API key:
             # https://docs.datadoghq.com/real_user_monitoring/guide/upload-javascript-source-maps/
             self.LOG('Could not find DATADOG_API_KEY environment variable while uploading source maps.')
-            return None, None
+            return None, None, None
 
         service = app_config.get('DATADOG_SERVICE')
         if not service:
             self.LOG('Could not find DATADOG_SERVICE for app {} while uploading source maps.'.format(self.app_name))
-            return None, None
+            return None, None, None
 
         # Determine version for deployment, prioritizing app-specific version override, if any, before
         # default APP_VERSION commit SHA version.
         version = app_config.get('DATADOG_VERSION') or app_config.get('APP_VERSION')
         if not version:
             self.LOG('Could not find version for app {} while uploading source maps.'.format(self.app_name))
-            return service, None
+            return service, None, None
 
         # Successfully determined service and version for the app deployment
-        return service, version
+        return service, version, app_config.get('DATADOG_REPOSITORY_URL')
+
+    def _get_datadog_repository_url(self, configured):
+        """
+        GitHub URL for linking stack frames to source, falling back to the checkout's
+        remote. Not derivable from the app name: 'frontend-app-course-authoring' lives
+        at edx/frontend-app-authoring.
+        """
+        if configured:
+            return configured
+        try:
+            return normalize_github_url(Repo(self.app_name).remotes.origin.url)
+        except (InvalidGitRepositoryError, NoSuchPathError, AttributeError, ValueError) as exc:
+            self.LOG('Could not read the git remote for app {}: {}'.format(self.app_name, exc))
+            return None
 
     def _upload_js_sourcemaps(self, app_dist):
         """ Upload JavaScript sourcemaps to Datadog. """
-        service, version = self._upload_js_sourcemaps_config()
+        service, version, configured_url = self._upload_js_sourcemaps_config()
         if not service or not version:
             # Could not determine appropriate service or version for app; skipping.
             return
 
-        command_args = ' '.join([
-            f'--service="{service}"',
-            f'--release-version="{version}"',
-            f'--project-path="{self.app_name}/"',
-            '--minified-path-prefix="/"',  # Sourcemaps are relative to the root when deployed
-            '--disable-git',  # Disable Datadog's git integration as the current working directory is not a git repo
-        ])
+        # Resolve before changing directory: both are relative to this script's working
+        # directory, where npm install put node_modules and the build put dist.
+        datadog_ci_bin = os.path.abspath('./node_modules/.bin/datadog-ci')
+        abs_app_dist = os.path.abspath(app_dist)
+
+        command = [
+            datadog_ci_bin, 'sourcemaps', 'upload', abs_app_dist,
+            '--service={}'.format(service),
+            '--release-version={}'.format(version),
+            '--minified-path-prefix=/',  # Sourcemaps are relative to the root when deployed
+            '--project-path=./',  # MFE sources live at the root of the repo
+        ]
+        repository_url = self._get_datadog_repository_url(configured_url)
+        if repository_url:
+            command.append('--repository-url={}'.format(repository_url))
+
         self.LOG('Uploading source maps to Datadog for app {}.'.format(self.app_name))
+        # datadog-ci reads the commit SHA (`git rev-parse HEAD`) and tracked file list
+        # (`git ls-files`) from its working directory, so it must run in the app checkout.
         proc = subprocess.Popen(
-            ' '.join([
-                './node_modules/.bin/datadog-ci sourcemaps upload',
-                app_dist,
-                command_args,
-            ]),
-            shell=True,
+            command,
+            cwd=self.app_name,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
         )
-        return_code = proc.wait()
-        if return_code != 0:
-            # If failure occurs, log the error and but don't fail the deployment.
+        output, _ = proc.communicate()
+        if output:
+            self.LOG(output.strip())
+        if proc.returncode != 0:
+            # If failure occurs, log the error but don't fail the deployment.
             self.LOG('Could not upload source maps to Datadog for app {}.'.format(self.app_name))
+        elif any(warning in output for warning in DATADOG_GIT_WARNINGS):
+            self.LOG(
+                'Source maps for app {} uploaded without git data; GitHub links will be '
+                'missing. Check the datadog-ci warning above.'.format(self.app_name)
+            )
 
     def deploy_site(self, bucket_name, app_dist):
         """ Deploy files to bucket. """

--- a/tubular/tests/test_frontend_deploy.py
+++ b/tubular/tests/test_frontend_deploy.py
@@ -1,0 +1,137 @@
+"""
+Tests for the Datadog sourcemap upload in frontend_utils.py. datadog-ci reads the
+repository URL and commit SHA from its own working directory, so these tests pin
+down the invocation rather than just its arguments.
+"""
+
+import os
+
+from unittest import TestCase, mock
+
+from git.exc import InvalidGitRepositoryError
+
+from ..scripts.frontend_utils import FrontendDeployer, normalize_github_url
+
+TEST_DATA_DIR = "tubular/tests/example-frontend-config"
+
+
+def build_deployer(app_config=None):
+    """ A deployer with config loading stubbed out, so tests stay focused on the upload. """
+    with mock.patch.object(FrontendDeployer, '_get_configs', return_value=({}, {})):
+        deployer = FrontendDeployer(
+            f"{TEST_DATA_DIR}/common.yml",
+            f"{TEST_DATA_DIR}/app.yml",
+            'frontend-app-coolfrontend',
+        )
+    deployer.LOG = mock.Mock()
+    deployer.FAIL = mock.Mock()
+    deployer.get_app_config = mock.Mock(return_value=app_config or {})
+    return deployer
+
+
+class TestNormalizeGithubUrl(TestCase):
+    """ Turning whatever git reports as ``origin`` into a URL Datadog can use. """
+
+    def test_remote_forms(self):
+        """ The organization is read from the remote, never assumed to be edx. """
+        edx, path = 'https://github.com/edx/frontend-app-foo', 'edx/frontend-app-foo'
+        for remote, expected in [
+                (f'git@github.com:{path}.git', edx),
+                (f'https://github.com/{path}.git', edx),
+                (f'ssh://git@github.com/{path}.git', edx),
+                (f'https://github.com/{path}', edx),
+                (f'https://user:token@github.com/{path}.git', edx),
+                ('git@github.com:openedx/frontend-app-foo.git', edx.replace('/edx/', '/openedx/')),
+                # Unusable -- datadog-ci auto-detects rather than sending a wrong link.
+                (None, None), ('', None), ('not-a-remote', None),
+                ('https://github.com/onlyone', None), (f'git@ghe.example.com:{path}.git', None),
+        ]:
+            assert normalize_github_url(remote) == expected, remote
+
+
+@mock.patch('tubular.scripts.frontend_utils.subprocess.Popen')
+class TestUploadJsSourcemaps(TestCase):
+    """ The datadog-ci invocation itself. """
+
+    def _upload(self, mock_popen, *, configured_url=None, repo_exc=None,
+                origin='git@github.com:edx/frontend-app-coolfrontend.git',
+                returncode=0, output=''):
+        """ Run the upload and return (deployer, command list, Popen kwargs). """
+        mock_popen.return_value.communicate.return_value = (output, None)
+        mock_popen.return_value.returncode = returncode
+        deployer = build_deployer()
+        repo = mock.Mock(**{'remotes.origin.url': origin})
+        repo_patch = mock.patch('tubular.scripts.frontend_utils.Repo',
+                                **({'side_effect': repo_exc} if repo_exc else {'return_value': repo}))
+        with repo_patch, mock.patch.object(
+                FrontendDeployer, '_upload_js_sourcemaps_config',
+                return_value=('edx-frontend-app-coolfrontend', 'abc123', configured_url)):
+            deployer._upload_js_sourcemaps('frontend-app-coolfrontend/dist')  # pylint: disable=protected-access
+        args, kwargs = mock_popen.call_args
+        return deployer, args[0], kwargs
+
+    def test_invocation(self, mock_popen):
+        """
+        The whole fix depends on the cwd: datadog-ci reads git from it. The paths are
+        relative to the deploy directory, so they must survive that change, and a list
+        rather than a shell string keeps paths with spaces from breaking quoting.
+        """
+        _, command, kwargs = self._upload(mock_popen)
+        assert kwargs['cwd'] == 'frontend-app-coolfrontend'
+        assert isinstance(command, list) and not kwargs.get('shell', False)
+        assert command[0].startswith('/') and command[0].endswith('/node_modules/.bin/datadog-ci')
+        assert command[3].startswith('/') and command[3].endswith('frontend-app-coolfrontend/dist')
+
+    def test_git_integration_is_enabled_at_the_repo_root(self, mock_popen):
+        """ MFE sources live at the repo root, not under a directory named for the app. """
+        _, command, _ = self._upload(mock_popen)
+        assert '--disable-git' not in command
+        assert '--project-path=./' in command
+        assert '--service=edx-frontend-app-coolfrontend' in command
+        assert '--release-version=abc123' in command
+        assert '--repository-url=https://github.com/edx/frontend-app-coolfrontend' in command
+
+    def test_explicit_repository_url_is_used_without_reading_git(self, mock_popen):
+        _, command, _ = self._upload(
+            mock_popen, configured_url='https://github.com/edx/elsewhere',
+            repo_exc=InvalidGitRepositoryError('would fail if consulted'))
+        assert '--repository-url=https://github.com/edx/elsewhere' in command
+
+    def test_unreadable_remote_omits_repository_url(self, mock_popen):
+        """ Upload without a link rather than failing, and say why in the log. """
+        deployer, command, _ = self._upload(mock_popen, repo_exc=InvalidGitRepositoryError('nope'))
+        assert not any(arg.startswith('--repository-url') for arg in command)
+        assert any('Could not read the git remote' in str(c) for c in deployer.LOG.call_args_list)
+
+    def test_nonzero_exit_is_logged_without_failing_the_deploy(self, mock_popen):
+        deployer, _, _ = self._upload(mock_popen, returncode=1)
+        assert any('Could not upload source maps' in str(c) for c in deployer.LOG.call_args_list)
+        deployer.FAIL.assert_not_called()
+
+    def test_git_warnings_on_zero_exit_are_surfaced(self, mock_popen):
+        """ datadog-ci warns and exits zero, so the return code alone hides all of these. """
+        for output, warned in [
+                ('An error occured while invoking git: fatal: not a git repository', True),
+                ('No tracked files found for sources contained in /dist/app.js.map', True),
+                ('Could not attach git data for sourcemap /dist/app.js.map: boom', True),
+                ('Uploaded 14 sourcemaps.', False),
+        ]:
+            deployer, _, _ = self._upload(mock_popen, output=output)
+            logged = any('without git data' in str(c) for c in deployer.LOG.call_args_list)
+            assert logged is warned, output
+
+    def test_config_carries_the_repository_url_override(self, _mock_popen):
+        """ Returned with service and version so get_app_config is read once, not twice. """
+        deployer = build_deployer({'DATADOG_SERVICE': 'svc', 'APP_VERSION': 'sha',
+                                   'DATADOG_REPOSITORY_URL': 'https://github.com/edx/x'})
+        with mock.patch.dict(os.environ, {'DATADOG_API_KEY': 'key'}):
+            assert deployer._upload_js_sourcemaps_config() == (  # pylint: disable=protected-access
+                'svc', 'sha', 'https://github.com/edx/x')
+        deployer.get_app_config.assert_called_once()
+
+    def test_skips_upload_when_service_or_version_missing(self, mock_popen):
+        deployer = build_deployer()
+        with mock.patch.object(FrontendDeployer, '_upload_js_sourcemaps_config',
+                               return_value=(None, None, None)):
+            deployer._upload_js_sourcemaps('dist')  # pylint: disable=protected-access
+        mock_popen.assert_not_called()


### PR DESCRIPTION
## Problem

Datadog Error Tracking shows **"Missing link to repository — Run datadog-ci from your Git repository to see links to your repository"** on MFE errors. No stack frame links back to GitHub, for any MFE.

## Root cause

`datadog-ci` reads the commit SHA (`git rev-parse HEAD`) and the tracked-files list (`git ls-files`) **from its own working directory**. From `@datadog/datadog-ci@2.48.0`, `helpers/git/format-git-sourcemaps-data.js`:

```js
const getRepositoryData = (git, repositoryURL) => {
    if (repositoryURL) {
        [hash, trackedFiles] = await Promise.all([gitHash(git), gitTrackedFiles(git)]);
        remote = repositoryURL;        // <- replaces ONLY the remote
    } ...
```

`--repository-url` substitutes the remote and nothing else. Both other values are still read from `process.cwd()`, and tubular runs `datadog-ci` from the deploy script's directory — not the app checkout. Datadog needs all three:

- `gitCommitSha` — the commit the link pins to
- `gitRepositoryPayload` — built from `git ls-files`, maps sourcemap `sources` onto real repo paths

`--disable-git` compounds this by turning the integration off outright. Its comment claims the CWD isn't a git repo — true, but the app directory one level down is, and the same class already reads HEAD from it (`Repo(self.app_name)`) and builds with `cwd=self.app_name`. The git metadata was never unavailable; the command just runs from the wrong directory.

**And the failure is silent.** `commands/sourcemaps/upload.js` catches the error, writes a warning to stdout, and exits **0**. Sourcemaps still upload, unminification keeps working, the deploy reports success — and no git data reaches Datadog.

## What this changes

`tubular/scripts/frontend_utils.py`, `_upload_js_sourcemaps()`:

- **Runs `datadog-ci` inside the app checkout** (`cwd=`). This is the load-bearing change; nothing else matters without it.
- **Removes `--disable-git`.**
- **`--project-path` `"{app_name}/"` → `"./"`.** Datadog needs paths relative to the repo root, and the repo root *is* that directory. Sources like `webpack:///./src/foo.tsx` were resolving to `<app-name>/src/foo.tsx`, which doesn't exist.
- **Resolves the binary and dist paths to absolute first.** Both are relative to the deploy script's CWD — `node_modules` lives there, and GoCD passes `--app-dist target/dist`. Without this the `cwd` change breaks the upload.
- **Derives `--repository-url` from the checkout's `origin` remote** via a new `normalize_github_url()`, which reads the owner and repo out of either an scp-style or URL remote. Returns `None` rather than guessing when they can't be determined, in which case datadog-ci falls back to its own auto-detection — better no link than a wrong one. `DATADOG_REPOSITORY_URL` in app config overrides it.
- **Surfaces the silent failures.** All three of `datadog-ci`'s zero-exit warnings — git unreadable, sources not matched to tracked files, git data not attached — now log an explicit message naming the consequence.

Reading the remote rather than assembling `edx/<app_name>` matters: `frontend-app-course-authoring` lives at `edx/frontend-app-authoring`, and `frontend-app-explore-catalog` at `edx/frontend-app-enterprise-public-catalog`. The convention would send both to the wrong repo, and reading the remote needs no maintenance as apps are added.

Also switches `Popen` from `shell=True` with a quoted string to `shell=False` with an argument list, so workspace paths containing spaces or shell metacharacters can't break the invocation.

**This applies to every MFE** — no hardcoded app names. The bug is uniform across the fleet, so the fix is too.

## Testing

New `tubular/tests/test_frontend_deploy.py` — 9 tests covering the `cwd`, absolute path resolution, absence of `--disable-git`, `--project-path=./`, edx and openedx remotes, the explicit config override, unreadable and unusable remotes, non-zero exit, and each zero-exit warning path.

`test_frontend_deploy.py`: 9 passed. Full suite: 267 passed / 51 failed / 3 skipped, against 258 / 51 / 3 on `master` in the same environment — the delta is exactly the new tests, failure count unchanged. Those 51 pre-existing failures are dependency-drift artifacts of a locally assembled environment (the repo pins `python_requires=">=3.6, <3.9"`); none are in modules that import `frontend_utils.py`. Three modules (`test_asgard`, `test_ec2`, `test_utils`) fail to import in that environment and were excluded from both runs — **CI should confirm those.**

pylint introduces no new findings — the `R1732 consider-using-with` on the `Popen` matches six pre-existing instances in the same file, and the `Popen` count is unchanged at 7 (one replaced, none added).

## Deploy environment

Verified from `edx-internal/gocd/generated-pipelines/output/<app>.yaml`:

| | |
|---|---|
| App checked out at deploy time? | Yes — `fetch_materials: true`, material `destination: frontend-app-<name>` |
| Remote on the agent | `git@github.com:edx/frontend-app-<name>.git` |
| `app_dist` | **relative** (`target/dist`) — hence the `abspath` |
| Full history for `rev-parse HEAD`? | Yes — `shallow_clone: false` |
| `node_modules` | deploy job root — `npm install` runs with no `cwd` |

## What to watch on the first deploy

1. Deploy log shows `Uploading source maps to Datadog for app <name>` with **none** of the new warnings after it.
2. Debug Symbols page — the **Domain** column, empty on every row so far, should populate for that service and version.
3. An error's stack frames carry GitHub links resolving to the built commit.

Note that **inline code snippets and team ownership are separate** — those need the Datadog GitHub App installed on the `edx` org, which is not configured. Their absence is not a failure of this change.
